### PR TITLE
Custom Material Shader System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ set(HP_SOURCES
     "${HP_ROOT_PATH}/source/Render/Scene/Scene.cpp"
 
     "${HP_ROOT_PATH}/source/Render/HP_ReflectionProbe.cpp"
+    "${HP_ROOT_PATH}/source/Render/HP_MaterialShader.cpp"
     "${HP_ROOT_PATH}/source/Render/HP_Cubemap.cpp"
     "${HP_ROOT_PATH}/source/Render/HP_Light.cpp"
     "${HP_ROOT_PATH}/source/Render/HP_Font.cpp"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here’s a checklist of the major features that are still missing:
 - [x] Bloom in post process
 - [x] Fog effect
 - [ ] Custom post-processing shaders
-- [ ] Custom material shaders
+- [x] Custom material shaders
 - [ ] More flexible 2D rendering
 - [ ] Audio spatialization
 

--- a/include/Hyperion/HP_Render.h
+++ b/include/Hyperion/HP_Render.h
@@ -1602,7 +1602,7 @@ HPAPI void HP_SetMaterialShaderTexture(HP_MaterialShader* shader, int slot, cons
  * @param size Size in bytes of the data to upload.
  * @param data Pointer to the data to upload.
  */
-HPAPI void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data);
+HPAPI void HP_UpdateStaticMaterialShaderBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data);
 
 /**
  * @brief Updates the dynamic uniform buffer of a material shader for the next draw call.
@@ -1618,7 +1618,7 @@ HPAPI void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offse
  * @param size Size in bytes of the data to upload.
  * @param data Pointer to the data to upload.
  */
-HPAPI void HP_UpdateDynamicMaterialBuffer(HP_MaterialShader* shader, size_t size, const void* data);
+HPAPI void HP_UpdateDynamicMaterialShaderBuffer(HP_MaterialShader* shader, size_t size, const void* data);
 
 /** @} */ // end of Material
 

--- a/include/Hyperion/HP_Render.h
+++ b/include/Hyperion/HP_Render.h
@@ -1527,26 +1527,79 @@ HPAPI void HP_DestroyMaterialResources(HP_Material* material);
  */
 
 /**
- * @brief Create a material shader from source code.
- * @param vertCode Vertex shader source code.
- * @param fragCode Fragment shader source code.
+ * @brief Creates a custom material shader from GLSL source code.
+ *
+ * Material shaders allow you to override the default rendering pipeline by providing
+ * custom vertex and/or fragment stages. At least one stage must be provided.
+ *
+ * Vertex stage (`void vertex()`) is called after material parameters and model/normal
+ * matrices are calculated but before the final vertex transformation. You can adjust
+ * positions in local space, colors, normals, etc.
+ *
+ * Fragment stage (`void fragment()`) is called after default albedo, ORM, and normal
+ * maps are computed, allowing you to override or tweak these values before lighting.
+ *
+ * You also have access to built-in global variables such as matrices, vertex attributes,
+ * and TIME.
+ *
+ * See the shader documentation for more details. (comming soon).
+ *
+ * @param vertCode Source code of the vertex shader stage (can be NULL if not used).
+ * @param fragCode Source code of the fragment shader stage (can be NULL if not used).
  * @return Pointer to the created HP_MaterialShader, or NULL on failure.
  */
 HPAPI HP_MaterialShader* HP_CreateMaterialShader(const char* vertCode, const char* fragCode);
 
 /**
- * @brief Load a material shader from GLSL source files.
- * @param vertFile Path to the vertex shader source file.
- * @param fragFile Path to the fragment shader source file.
+ * @brief Loads a custom material shader from GLSL source files.
+ *
+ * Same behavior as HP_CreateMaterialShader, but loads the shader code from files.
+ *
+ * @param vertFile Path to the vertex shader file (can be NULL if not used).
+ * @param fragFile Path to the fragment shader file (can be NULL if not used).
  * @return Pointer to the created HP_MaterialShader, or NULL on failure.
  */
 HPAPI HP_MaterialShader* HP_LoadMaterialShader(const char* vertFile, const char* fragFile);
 
 /**
- * @brief Destroy a material shader.
+ * @brief Destroys a material shader and releases associated GPU resources.
+ * 
  * @param shader Pointer to the HP_MaterialShader to destroy.
  */
-void HP_DestroyMaterialShader(HP_MaterialShader* shader);
+HPAPI void HP_DestroyMaterialShader(HP_MaterialShader* shader);
+
+/**
+ * @brief Updates the static uniform buffer of a material shader.
+ *
+ * Static buffers are defined in the shader as an uniform block named `StaticBuffer`.
+ * They are constant across all draw calls using this shader. If multiple updates are
+ * made during a frame, only the last update takes effect.
+ *
+ * @note Static buffers can be updated partially or completely.
+ * @note The uniform block must use `std140` layout and respect 16-byte alignment and padding rules.
+ *
+ * @param shader Pointer to the HP_MaterialShader.
+ * @param offset Offset in bytes into the StaticBuffer to update.
+ * @param size Size in bytes of the data to upload.
+ * @param data Pointer to the data to upload.
+ */
+HPAPI void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data);
+
+/**
+ * @brief Updates the dynamic uniform buffer of a material shader for the next draw call.
+ *
+ * Dynamic buffers are defined in the shader as an uniform block named `DynamicBuffer`.
+ * They are cleared at the end of each frame and can be set independently for each draw call.
+ * This allows you to have different dynamic data per draw call.
+ *
+ * @note Dynamic buffers must be fully uploaded in a single call.
+ * @note The uniform block must use `std140` layout and respect 16-byte alignment and padding rules.
+ *
+ * @param shader Pointer to the HP_MaterialShader.
+ * @param size Size in bytes of the data to upload.
+ * @param data Pointer to the data to upload.
+ */
+HPAPI void HP_UpdateDynamicMaterialBuffer(HP_MaterialShader* shader, size_t size, const void* data);
 
 /** @} */ // end of Material
 

--- a/include/Hyperion/HP_Render.h
+++ b/include/Hyperion/HP_Render.h
@@ -1569,6 +1569,25 @@ HPAPI HP_MaterialShader* HP_LoadMaterialShader(const char* vertFile, const char*
 HPAPI void HP_DestroyMaterialShader(HP_MaterialShader* shader);
 
 /**
+ * @brief Assign a texture to a material shader sampler.
+ *
+ * This function sets a texture for a specific sampler slot in a material shader.
+ * The shader must declare the sampler with one of the predefined names:
+ * "Texture0", "Texture1", "Texture2", or "Texture3", all of type `sampler2D`.
+ *
+ * If `texture` is `NULL`, a default white texture will be used instead.
+ *
+ * @param shader Pointer to the HP_MaterialShader to modify.
+ * @param slot Index of the sampler to assign (0 to 3). The slot must correspond
+ *             to a sampler declared in the shader with the matching name.
+ * @param texture Pointer to the HP_Texture to bind, or `NULL` to use a white texture.
+ *
+ * @note Up to 4 texture samplers are supported per shader. It is the user's
+ *       responsibility to ensure the shader defines the corresponding sampler names.
+ */
+HPAPI void HP_SetMaterialShaderTexture(HP_MaterialShader* shader, int slot, const HP_Texture* texture);
+
+/**
  * @brief Updates the static uniform buffer of a material shader.
  *
  * Static buffers are defined in the shader as an uniform block named `StaticBuffer`.

--- a/include/Hyperion/HP_Render.h
+++ b/include/Hyperion/HP_Render.h
@@ -319,6 +319,14 @@ typedef struct HP_Light HP_Light;
  */
 typedef struct HP_Font HP_Font;
 
+/**
+ * @brief Opaque handle to a material shader.
+ *
+ * Represents a customizable shader used by a material.
+ * Provides overrideable vertex/fragment entry points.
+ */
+typedef struct HP_MaterialShader HP_MaterialShader;
+
 /* === Structures === */
 
 /**
@@ -525,6 +533,8 @@ typedef struct HP_Material {
     HP_BillboardMode billboard;     ///< Billboard mode applied to the object
     HP_BlendMode blend;             ///< Blending mode for rendering. Default: Opaque
     HP_CullMode cull;               ///< Face culling mode. Default: Back face
+
+    HP_MaterialShader* shader;      ///< Pointer to an optional material shader. Default: NULL
 
 } HP_Material;
 
@@ -1497,6 +1507,7 @@ HPAPI void HP_UpdateReflectionProbe(HP_ReflectionProbe* probe, const HP_Cubemap*
  * - texScale: (1, 1)
  * - blend mode: HP_BLEND_OPAQUE
  * - cull mode: HP_CULL_BACK
+ * - shader: NULL
  */
 HPAPI HP_Material HP_GetDefaultMaterial(void);
 
@@ -1507,6 +1518,35 @@ HPAPI HP_Material HP_GetDefaultMaterial(void);
  * @note Do not call this if the resources are shared between multiple materials.
  */
 HPAPI void HP_DestroyMaterialResources(HP_Material* material);
+
+/** @} */ // end of Material
+
+/**
+ * @defgroup Material Material Functions
+ * @{
+ */
+
+/**
+ * @brief Create a material shader from source code.
+ * @param vertCode Vertex shader source code.
+ * @param fragCode Fragment shader source code.
+ * @return Pointer to the created HP_MaterialShader, or NULL on failure.
+ */
+HPAPI HP_MaterialShader* HP_CreateMaterialShader(const char* vertCode, const char* fragCode);
+
+/**
+ * @brief Load a material shader from GLSL source files.
+ * @param vertFile Path to the vertex shader source file.
+ * @param fragFile Path to the fragment shader source file.
+ * @return Pointer to the created HP_MaterialShader, or NULL on failure.
+ */
+HPAPI HP_MaterialShader* HP_LoadMaterialShader(const char* vertFile, const char* fragFile);
+
+/**
+ * @brief Destroy a material shader.
+ * @param shader Pointer to the HP_MaterialShader to destroy.
+ */
+void HP_DestroyMaterialShader(HP_MaterialShader* shader);
 
 /** @} */ // end of Material
 

--- a/scripts/glsl_processor.py
+++ b/scripts/glsl_processor.py
@@ -111,8 +111,8 @@ def process_shader(filepath):
 
     shader_content = process_includes(shader_content, filepath.parent)
     shader_content = remove_comments(shader_content)
-    shader_content = remove_newlines(shader_content)
-    shader_content = normalize_spaces(shader_content)
+    #shader_content = remove_newlines(shader_content)
+    #shader_content = normalize_spaces(shader_content)
 
     return shader_content
 

--- a/shaders/include/frame.glsl
+++ b/shaders/include/frame.glsl
@@ -28,4 +28,5 @@ struct FrameShadow {
     vec3 lightPosition;
     float shadowLambda;
     float farPlane;
+    float elapsedTime;
 };

--- a/shaders/include/frame.glsl
+++ b/shaders/include/frame.glsl
@@ -6,7 +6,10 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-struct Frame {
+/**
+ * Used in 'forward' and 'prepass' shaders
+ */
+struct FrameForward {
     uvec2 screenSize;               // Render target dimensions
     uvec3 clusterCount;
     uint  maxLightsPerCluster;
@@ -15,4 +18,14 @@ struct Frame {
     float elapsedTime;
     bool hasActiveLights;
     bool hasProbe;
+};
+
+/**
+ * Used in 'shadow' shaders (render to shadow maps)
+ */
+struct FrameShadow {
+    mat4 lightViewProj;
+    vec3 lightPosition;
+    float shadowLambda;
+    float farPlane;
 };

--- a/shaders/include/frame.glsl
+++ b/shaders/include/frame.glsl
@@ -1,0 +1,18 @@
+/* billboard.glsl -- Contains everything related to frame infos
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+struct Frame {
+    uvec2 screenSize;               // Render target dimensions
+    uvec3 clusterCount;
+    uint  maxLightsPerCluster;
+    float clusterSliceScale;
+    float clusterSliceBias;
+    float elapsedTime;
+    bool hasActiveLights;
+    bool hasProbe;
+};

--- a/shaders/include/template/scene.frag
+++ b/shaders/include/template/scene.frag
@@ -6,7 +6,11 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-/* === Inputs === */
+/* === Includes === */
+
+#include "../math.glsl"
+
+/* === Constants === */
 
 #define TIME            uRender.time
 

--- a/shaders/include/template/scene.frag
+++ b/shaders/include/template/scene.frag
@@ -6,6 +6,10 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
+/* === Inputs === */
+
+#define TIME            uRender.time
+
 /* === Outputs === */
 
 vec4 ALBEDO             = vec4(1.0);

--- a/shaders/include/template/scene.frag
+++ b/shaders/include/template/scene.frag
@@ -6,6 +6,8 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
+/* === Outputs === */
+
 vec4 ALBEDO             = vec4(1.0);
 vec3 EMISSION           = vec3(0.0);
 float AO_LIGHT_AFFECT   = 0.0;
@@ -15,13 +17,12 @@ float METALNESS         = 0.0;
 vec3 NORMAL_MAP         = vec3(0.0, 0.0, 1.0);
 float NORMAL_SCALE      = 1.0;
 
+/* === Override === */
+
 #define fragment() //< The macro can be replaced by user code
 
 void FragmentOverride()
 {
-    // TODO: We shouldn't be sampling on behalf of the user
-    //       but for now this is 100% consistent with vertex()
-
     ALBEDO = vColor * uMaterial.albedoColor * texture(uTexAlbedo, vTexCoord);
 
     EMISSION = uMaterial.emissionColor * texture(uTexEmission, vTexCoord).rgb;

--- a/shaders/include/template/scene.frag
+++ b/shaders/include/template/scene.frag
@@ -1,0 +1,41 @@
+/* scene.frag -- Scene fragment shader override template
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+vec4 ALBEDO             = vec4(1.0);
+vec3 EMISSION           = vec3(0.0);
+float AO_LIGHT_AFFECT   = 0.0;
+float OCCLUSION         = 1.0;
+float ROUGHNESS         = 1.0;
+float METALNESS         = 0.0;
+vec3 NORMAL_MAP         = vec3(0.0, 0.0, 1.0);
+float NORMAL_SCALE      = 1.0;
+
+#define fragment() //< The macro can be replaced by user code
+
+void FragmentOverride()
+{
+    // TODO: We shouldn't be sampling on behalf of the user
+    //       but for now this is 100% consistent with vertex()
+
+    ALBEDO = vColor * uMaterial.albedoColor * texture(uTexAlbedo, vTexCoord);
+
+    EMISSION = uMaterial.emissionColor * texture(uTexEmission, vTexCoord).rgb;
+    EMISSION *= uMaterial.emissionEnergy;
+
+    AO_LIGHT_AFFECT = uMaterial.aoLightAffect;
+
+    vec3 orm = texture(uTexORM, vTexCoord).rgb;
+    OCCLUSION = uMaterial.occlusion * orm.x;
+    ROUGHNESS = uMaterial.roughness * orm.y;
+    METALNESS = uMaterial.metalness * orm.z;
+
+    NORMAL_MAP = texture(uTexNormal, vTexCoord).rgb;
+    NORMAL_SCALE = uMaterial.normalScale;
+
+    fragment();
+}

--- a/shaders/include/template/scene.frag
+++ b/shaders/include/template/scene.frag
@@ -13,6 +13,9 @@
 /* === Constants === */
 
 #define TIME            uRender.time
+#define POSITION        vPosition
+#define TEXCOORD        vTexCoord
+#define NORMAL          vTBN[3]
 
 /* === Outputs === */
 

--- a/shaders/include/template/scene.frag
+++ b/shaders/include/template/scene.frag
@@ -12,7 +12,7 @@
 
 /* === Constants === */
 
-#define TIME            uRender.time
+#define TIME            uFrame.elapsedTime
 #define POSITION        vPosition
 #define TEXCOORD        vTexCoord
 #define NORMAL          vTBN[3]

--- a/shaders/include/template/scene.vert
+++ b/shaders/include/template/scene.vert
@@ -6,7 +6,11 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
-/* === Inputs === */
+/* === Includes === */
+
+#include "../math.glsl"
+
+/* === Constants === */
 
 #define TIME            uRender.time
 #define INSTANCE_DATA   iCustom

--- a/shaders/include/template/scene.vert
+++ b/shaders/include/template/scene.vert
@@ -1,0 +1,26 @@
+/* scene.vert -- Scene vertex shader override template
+ *
+ * Copyright (c) 2025 Le Juez Victor
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * For conditions of distribution and use, see accompanying LICENSE file.
+ */
+
+vec3 POSITION   = vec3(0.0);
+vec2 TEXCOORD   = vec2(0.0);
+vec4 COLOR      = vec4(1.0);
+vec3 NORMAL     = vec3(0.0, 0.0, 1.0);
+vec4 TANGENT    = vec4(0.0, 0.0, 0.0, 1.0);
+
+#define vertex() //< The macro can be replaced by user code
+
+void VertexOverride()
+{
+    POSITION = aPosition;
+    TEXCOORD = uMaterial.texOffset + aTexCoord * uMaterial.texScale;
+    COLOR = aColor * iColor;
+    NORMAL = aNormal;
+    TANGENT = aTangent;
+
+    vertex();
+}

--- a/shaders/include/template/scene.vert
+++ b/shaders/include/template/scene.vert
@@ -6,11 +6,19 @@
  * For conditions of distribution and use, see accompanying LICENSE file.
  */
 
+/* === Inputs === */
+
+#define INSTANCE_DATA   iCustom
+
+/* === Outputs === */
+
 vec3 POSITION   = vec3(0.0);
 vec2 TEXCOORD   = vec2(0.0);
 vec4 COLOR      = vec4(1.0);
 vec3 NORMAL     = vec3(0.0, 0.0, 1.0);
 vec4 TANGENT    = vec4(0.0, 0.0, 0.0, 1.0);
+
+/* === Override === */
 
 #define vertex() //< The macro can be replaced by user code
 

--- a/shaders/include/template/scene.vert
+++ b/shaders/include/template/scene.vert
@@ -12,7 +12,7 @@
 
 /* === Constants === */
 
-#define TIME            uRender.time
+#define TIME            uFrame.elapsedTime
 #define INSTANCE_DATA   iCustom
 
 /* === Outputs === */

--- a/shaders/include/template/scene.vert
+++ b/shaders/include/template/scene.vert
@@ -8,6 +8,7 @@
 
 /* === Inputs === */
 
+#define TIME            uRender.time
 #define INSTANCE_DATA   iCustom
 
 /* === Outputs === */

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -86,7 +86,7 @@ layout(binding = 8) uniform highp sampler2DArray uTexShadow2D;
 /* === Uniform Buffers === */
 
 layout(std140, binding = 0) uniform U_Frame {
-    Frame uFrame;
+    FrameForward uFrame;
 };
 
 layout(std140, binding = 1) uniform U_ViewFrustum {

--- a/shaders/scene/forward.frag
+++ b/shaders/scene/forward.frag
@@ -99,6 +99,7 @@ layout(std140, binding = 2) uniform U_Renderable {
     uint layerMask;
     bool instancing;
     bool skinning;
+    float time;
 } uRender;
 
 layout(std140, binding = 3) uniform U_Material {

--- a/shaders/scene/forward.vert
+++ b/shaders/scene/forward.vert
@@ -49,6 +49,7 @@ layout(std140, binding = 2) uniform U_Renderable {
     uint layerMask;
     bool instancing;
     bool skinning;
+    float time;
 } uRender;
 
 layout(std140, binding = 3) uniform U_Material {

--- a/shaders/scene/forward.vert
+++ b/shaders/scene/forward.vert
@@ -14,8 +14,10 @@ precision highp float;
 
 /* === Includes === */
 
+#include "../include/environment.glsl"
 #include "../include/billboard.glsl"
 #include "../include/frustum.glsl"
+#include "../include/frame.glsl"
 
 /* === Attributes === */
 
@@ -38,21 +40,28 @@ layout(std430, binding = 4) buffer BoneBuffer {
 
 /* === Uniform Buffers === */
 
-layout(std140, binding = 0) uniform U_ViewFrustum {
+layout(std140, binding = 0) uniform U_Frame {
+    Frame uFrame;
+};
+
+layout(std140, binding = 1) uniform U_ViewFrustum {
     Frustum uFrustum;
 };
 
-layout(std140, binding = 2) uniform U_Renderable {
+layout(std140, binding = 2) uniform U_Environment {
+    Environment uEnv;
+};
+
+layout(std140, binding = 3) uniform U_Renderable {
     mat4 matModel;
     mat4 matNormal;
     int boneOffset;
     uint layerMask;
     bool instancing;
     bool skinning;
-    float time;
 } uRender;
 
-layout(std140, binding = 3) uniform U_Material {
+layout(std140, binding = 4) uniform U_Material {
     vec4 albedoColor;
     vec3 emissionColor;
     float emissionEnergy;

--- a/shaders/scene/forward.vert
+++ b/shaders/scene/forward.vert
@@ -41,7 +41,7 @@ layout(std430, binding = 4) buffer BoneBuffer {
 /* === Uniform Buffers === */
 
 layout(std140, binding = 0) uniform U_Frame {
-    Frame uFrame;
+    FrameForward uFrame;
 };
 
 layout(std140, binding = 1) uniform U_ViewFrustum {

--- a/shaders/scene/forward.vert
+++ b/shaders/scene/forward.vert
@@ -64,7 +64,7 @@ layout(std140, binding = 3) uniform U_Material {
     vec2 texOffset;
     vec2 texScale;
     int billboard;
-} uMat;
+} uMaterial;
 
 /* === Varyings === */
 
@@ -72,6 +72,10 @@ layout(location = 0) out vec3 vPosition;
 layout(location = 1) out vec2 vTexCoord;
 layout(location = 2) out vec4 vColor;
 layout(location = 3) out mat3 vTBN;
+
+/* === Vertex Override === */
+
+#include "../include/template/scene.vert"
 
 /* === Helper Functions === */
 
@@ -87,6 +91,8 @@ mat4 SkinMatrix(ivec4 boneIDs, vec4 weights, int offset)
 
 void main()
 {
+    /* --- Calculation of matrices --- */
+
     mat4 matModel = uRender.matModel;
     mat3 matNormal = mat3(uRender.matNormal);
 
@@ -101,7 +107,7 @@ void main()
         matNormal = mat3(transpose(inverse(iMatModel))) * matNormal;
     }
 
-    switch(uMat.billboard) {
+    switch(uMaterial.billboard) {
     case BILLBOARD_NONE:
         break;
     case BILLBOARD_FRONT:
@@ -112,13 +118,17 @@ void main()
         break;
     }
 
-    vec3 T = normalize(matNormal * aTangent.xyz);
-    vec3 N = normalize(matNormal * aNormal);
-    vec3 B = normalize(cross(N, T) * aTangent.w);
+    /* --- Call vertex override and final vertex calculation --- */
 
-    vPosition = vec3(matModel * vec4(aPosition, 1.0));
-    vTexCoord = uMat.texOffset + aTexCoord * uMat.texScale;
-    vColor = aColor * iColor * uMat.albedoColor;
+    VertexOverride();
+
+    vec3 T = normalize(matNormal * TANGENT.xyz);
+    vec3 N = normalize(matNormal * NORMAL);
+    vec3 B = normalize(cross(N, T) * TANGENT.w);
+
+    vPosition = vec3(matModel * vec4(POSITION, 1.0));
+    vTexCoord = TEXCOORD;
+    vColor = COLOR;
     vTBN = mat3(T, B, N);
 
     gl_Position = uFrustum.viewProj * vec4(vPosition, 1.0);

--- a/shaders/scene/prepass.frag
+++ b/shaders/scene/prepass.frag
@@ -23,7 +23,7 @@ layout(binding = 0) uniform sampler2D uTexAlbedo;
 
 /* === Uniforms === */
 
-layout(std140, binding = 3) uniform U_Material {
+layout(std140, binding = 4) uniform U_Material {
     vec4 albedoColor;
     vec3 emissionColor;
     float emissionEnergy;

--- a/shaders/scene/prepass.frag
+++ b/shaders/scene/prepass.frag
@@ -36,12 +36,12 @@ layout(std140, binding = 3) uniform U_Material {
     vec2 texOffset;
     vec2 texScale;
     int billboard;
-} uMat;
+} uMaterial;
 
 /* === Program === */
 
 void main()
 {
     float alpha = vAlpha * texture(uTexAlbedo, vTexCoord).a;
-    if (alpha < uMat.alphaCutOff) discard;
+    if (alpha < uMaterial.alphaCutOff) discard;
 }

--- a/shaders/scene/prepass.vert
+++ b/shaders/scene/prepass.vert
@@ -49,6 +49,7 @@ layout(std140, binding = 2) uniform U_Renderable {
     uint layerMask;
     bool instancing;
     bool skinning;
+    float time;
 } uRender;
 
 layout(std140, binding = 3) uniform U_Material {

--- a/shaders/scene/prepass.vert
+++ b/shaders/scene/prepass.vert
@@ -14,8 +14,10 @@ precision highp float;
 
 /* === Includes === */
 
+#include "../include/environment.glsl"
 #include "../include/billboard.glsl"
 #include "../include/frustum.glsl"
+#include "../include/frame.glsl"
 
 /* === Attributes === */
 
@@ -38,21 +40,28 @@ layout(std430, binding = 4) buffer BoneBuffer {
 
 /* === Uniform Buffers === */
 
-layout(std140, binding = 0) uniform U_ViewFrustum {
+layout(std140, binding = 0) uniform U_Frame {
+    Frame uFrame;
+};
+
+layout(std140, binding = 1) uniform U_ViewFrustum {
     Frustum uFrustum;
 };
 
-layout(std140, binding = 2) uniform U_Renderable {
+layout(std140, binding = 2) uniform U_Environment {
+    Environment uEnv;
+};
+
+layout(std140, binding = 3) uniform U_Renderable {
     mat4 matModel;
     mat4 matNormal;
     int boneOffset;
     uint layerMask;
     bool instancing;
     bool skinning;
-    float time;
 } uRender;
 
-layout(std140, binding = 3) uniform U_Material {
+layout(std140, binding = 4) uniform U_Material {
     vec4 albedoColor;
     vec3 emissionColor;
     float emissionEnergy;

--- a/shaders/scene/prepass.vert
+++ b/shaders/scene/prepass.vert
@@ -41,7 +41,7 @@ layout(std430, binding = 4) buffer BoneBuffer {
 /* === Uniform Buffers === */
 
 layout(std140, binding = 0) uniform U_Frame {
-    Frame uFrame;
+    FrameForward uFrame;
 };
 
 layout(std140, binding = 1) uniform U_ViewFrustum {

--- a/shaders/scene/prepass.vert
+++ b/shaders/scene/prepass.vert
@@ -21,11 +21,14 @@ precision highp float;
 
 layout(location = 0) in vec3 aPosition;
 layout(location = 1) in vec2 aTexCoord;
+layout(location = 2) in vec3 aNormal;
+layout(location = 3) in vec4 aTangent;
 layout(location = 4) in vec4 aColor;
 layout(location = 5) in ivec4 aBoneIDs;
 layout(location = 6) in vec4 aWeights;
 layout(location = 7) in mat4 iMatModel;
 layout(location = 11) in vec4 iColor;
+layout(location = 12) in vec4 iCustom;
 
 /* === Storage Buffers === */
 
@@ -61,12 +64,16 @@ layout(std140, binding = 3) uniform U_Material {
     vec2 texOffset;
     vec2 texScale;
     int billboard;
-} uMat;
+} uMaterial;
 
 /* === Varyings === */
 
 layout(location = 0) out vec2 vTexCoord;
 layout(location = 1) out float vAlpha;
+
+/* === Vertex Override === */
+
+#include "../include/template/scene.vert"
 
 /* === Helper Functions === */
 
@@ -82,6 +89,8 @@ mat4 SkinMatrix(ivec4 boneIDs, vec4 weights, int offset)
 
 void main()
 {
+    /* --- Calculation of matrices --- */
+
     mat4 matModel = uRender.matModel;
 
     if (uRender.skinning) {
@@ -93,7 +102,7 @@ void main()
         matModel = iMatModel * matModel;
     }
 
-    switch(uMat.billboard) {
+    switch(uMaterial.billboard) {
     case BILLBOARD_NONE:
         break;
     case BILLBOARD_FRONT:
@@ -104,9 +113,13 @@ void main()
         break;
     }
 
-    vec3 position = vec3(matModel * vec4(aPosition, 1.0));
-    vTexCoord = uMat.texOffset + aTexCoord * uMat.texScale;
-    vAlpha = aColor.a * iColor.a * uMat.albedoColor.a;
+    /* --- Call vertex override and final vertex calculation --- */
+
+    VertexOverride();
+
+    vec3 position = vec3(matModel * vec4(POSITION, 1.0));
+    vTexCoord = TEXCOORD;
+    vAlpha = COLOR.a;
 
     gl_Position = uFrustum.viewProj * vec4(position, 1.0);
 }

--- a/shaders/scene/shadow.frag
+++ b/shaders/scene/shadow.frag
@@ -22,12 +22,28 @@ layout(location = 2) in float vAlpha;
 
 layout(binding = 0) uniform sampler2D uTexAlbedo;
 
+/* === Uniform Buffers === */
+
+layout(std140, binding = 3) uniform U_Material {
+    vec4 albedoColor;
+    vec3 emissionColor;
+    float emissionEnergy;
+    float aoLightAffect;
+    float occlusion;
+    float roughness;
+    float metalness;
+    float normalScale;
+    float alphaCutOff;
+    vec2 texOffset;
+    vec2 texScale;
+    int billboard;
+} uMat;
+
 /* === Uniforms === */
 
-layout(location = 10) uniform vec3 uLightPosition;
-layout(location = 11) uniform float uAlphaCutOff;
-layout(location = 12) uniform float uLambda;
-layout(location = 13) uniform float uFar;
+layout(location = 1) uniform vec3 uLightPosition;
+layout(location = 2) uniform float uLambda;
+layout(location = 3) uniform float uFar;
 
 /* === Fragments === */
 
@@ -38,7 +54,7 @@ layout(location = 0) out vec4 FragDistance;
 void main()
 {
     float alpha = vAlpha * texture(uTexAlbedo, vTexCoord).a;
-    if (alpha < uAlphaCutOff) discard;
+    if (alpha < uMat.alphaCutOff) discard;
 
     // Normalized linear distance in [0,1]
     float d01 = length(vPosition - uLightPosition) / uFar;

--- a/shaders/scene/shadow.frag
+++ b/shaders/scene/shadow.frag
@@ -12,6 +12,10 @@
 precision highp float;
 #endif
 
+/* === Includes === */
+
+#include "../include/frame.glsl"
+
 /* === Varyings === */
 
 layout(location = 0) in vec3 vPosition;
@@ -24,7 +28,11 @@ layout(binding = 0) uniform sampler2D uTexAlbedo;
 
 /* === Uniform Buffers === */
 
-layout(std140, binding = 3) uniform U_Material {
+layout(std140, binding = 0) uniform U_Frame {
+    FrameShadow uFrame;
+};
+
+layout(std140, binding = 4) uniform U_Material {
     vec4 albedoColor;
     vec3 emissionColor;
     float emissionEnergy;
@@ -39,12 +47,6 @@ layout(std140, binding = 3) uniform U_Material {
     int billboard;
 } uMaterial;
 
-/* === Uniforms === */
-
-layout(location = 1) uniform vec3 uLightPosition;
-layout(location = 2) uniform float uLambda;
-layout(location = 3) uniform float uFar;
-
 /* === Fragments === */
 
 layout(location = 0) out vec4 FragDistance;
@@ -57,7 +59,7 @@ void main()
     if (alpha < uMaterial.alphaCutOff) discard;
 
     // Normalized linear distance in [0,1]
-    float d01 = length(vPosition - uLightPosition) / uFar;
+    float d01 = length(vPosition - uFrame.lightPosition) / uFrame.farPlane;
 
 #ifdef GL_ES
     // VSM
@@ -66,8 +68,8 @@ void main()
     FragDistance = vec4(m1, m2, 0.0, 1.0);
 #else
     // EVSM
-    float pExp = exp(+uLambda * d01);
-    float nExp = exp(-uLambda * d01);
+    float pExp = exp(+uFrame.shadowLambda * d01);
+    float nExp = exp(-uFrame.shadowLambda * d01);
     FragDistance = vec4(pExp, nExp, 0.0, 1.0);
 #endif
 }

--- a/shaders/scene/shadow.frag
+++ b/shaders/scene/shadow.frag
@@ -37,7 +37,7 @@ layout(std140, binding = 3) uniform U_Material {
     vec2 texOffset;
     vec2 texScale;
     int billboard;
-} uMat;
+} uMaterial;
 
 /* === Uniforms === */
 
@@ -54,7 +54,7 @@ layout(location = 0) out vec4 FragDistance;
 void main()
 {
     float alpha = vAlpha * texture(uTexAlbedo, vTexCoord).a;
-    if (alpha < uMat.alphaCutOff) discard;
+    if (alpha < uMaterial.alphaCutOff) discard;
 
     // Normalized linear distance in [0,1]
     float d01 = length(vPosition - uLightPosition) / uFar;

--- a/shaders/scene/shadow.vert
+++ b/shaders/scene/shadow.vert
@@ -14,8 +14,10 @@ precision highp float;
 
 /* === Includes === */
 
+#include "../include/environment.glsl"
 #include "../include/billboard.glsl"
 #include "../include/frustum.glsl"
+#include "../include/frame.glsl"
 
 /* === Attributes === */
 
@@ -38,11 +40,19 @@ layout(std430, binding = 0) buffer BoneBuffer {
 
 /* === Uniform Buffers === */
 
-layout(std140, binding = 0) uniform U_ViewFrustum {
+layout(std140, binding = 0) uniform U_Frame {
+    FrameShadow uFrame;
+};
+
+layout(std140, binding = 1) uniform U_ViewFrustum {
     Frustum uFrustum;
 };
 
-layout(std140, binding = 2) uniform U_Renderable {
+layout(std140, binding = 2) uniform U_Environment {
+    Environment uEnv;
+};
+
+layout(std140, binding = 3) uniform U_Renderable {
     mat4 matModel;
     mat4 matNormal;
     int boneOffset;
@@ -51,7 +61,7 @@ layout(std140, binding = 2) uniform U_Renderable {
     bool skinning;
 } uRender;
 
-layout(std140, binding = 3) uniform U_Material {
+layout(std140, binding = 4) uniform U_Material {
     vec4 albedoColor;
     vec3 emissionColor;
     float emissionEnergy;
@@ -65,10 +75,6 @@ layout(std140, binding = 3) uniform U_Material {
     vec2 texScale;
     int billboard;
 } uMaterial;
-
-/* === Uniforms === */
-
-layout(location = 0) uniform mat4 uLightViewProj;
 
 /* === Varyings === */
 
@@ -126,5 +132,5 @@ void main()
     vTexCoord = TEXCOORD;
     vAlpha = COLOR.a;
 
-    gl_Position = uLightViewProj * vec4(vPosition, 1.0);
+    gl_Position = uFrame.lightViewProj * vec4(vPosition, 1.0);
 }

--- a/shaders/scene/shadow.vert
+++ b/shaders/scene/shadow.vert
@@ -49,6 +49,7 @@ layout(std140, binding = 2) uniform U_Renderable {
     uint layerMask;
     bool instancing;
     bool skinning;
+    float time;
 } uRender;
 
 layout(std140, binding = 3) uniform U_Material {

--- a/shaders/scene/shadow.vert
+++ b/shaders/scene/shadow.vert
@@ -21,11 +21,14 @@ precision highp float;
 
 layout(location = 0) in vec3 aPosition;
 layout(location = 1) in vec2 aTexCoord;
+layout(location = 2) in vec3 aNormal;
+layout(location = 3) in vec4 aTangent;
 layout(location = 4) in vec4 aColor;
 layout(location = 5) in ivec4 aBoneIDs;
 layout(location = 6) in vec4 aWeights;
 layout(location = 7) in mat4 iMatModel;
 layout(location = 11) in vec4 iColor;
+layout(location = 12) in vec4 iCustom;
 
 /* === Storage Buffers === */
 
@@ -61,7 +64,7 @@ layout(std140, binding = 3) uniform U_Material {
     vec2 texOffset;
     vec2 texScale;
     int billboard;
-} uMat;
+} uMaterial;
 
 /* === Uniforms === */
 
@@ -72,6 +75,10 @@ layout(location = 0) uniform mat4 uLightViewProj;
 layout(location = 0) out vec3 vPosition;
 layout(location = 1) out vec2 vTexCoord;
 layout(location = 2) out float vAlpha;
+
+/* === Vertex Override === */
+
+#include "../include/template/scene.vert"
 
 /* === Helper Functions === */
 
@@ -87,6 +94,8 @@ mat4 SkinMatrix(ivec4 boneIDs, vec4 weights, int offset)
 
 void main()
 {
+    /* --- Calculation of matrices --- */
+
     mat4 matModel = uRender.matModel;
 
     if (uRender.skinning) {
@@ -98,7 +107,7 @@ void main()
         matModel = iMatModel * matModel;
     }
 
-    switch(uMat.billboard) {
+    switch(uMaterial.billboard) {
     case BILLBOARD_NONE:
         break;
     case BILLBOARD_FRONT:
@@ -109,9 +118,13 @@ void main()
         break;
     }
 
-    vPosition = vec3(matModel * vec4(aPosition, 1.0));
-    vTexCoord = uMat.texOffset + aTexCoord * uMat.texScale;
-    vAlpha = aColor.a * iColor.a * uMat.albedoColor.a;
+    /* --- Call vertex override and final vertex calculation --- */
+
+    VertexOverride();
+
+    vPosition = vec3(matModel * vec4(POSITION, 1.0));
+    vTexCoord = TEXCOORD;
+    vAlpha = COLOR.a;
 
     gl_Position = uLightViewProj * vec4(vPosition, 1.0);
 }

--- a/shaders/scene/shadow.vert
+++ b/shaders/scene/shadow.vert
@@ -49,7 +49,6 @@ layout(std140, binding = 2) uniform U_Renderable {
     uint layerMask;
     bool instancing;
     bool skinning;
-    float time;
 } uRender;
 
 layout(std140, binding = 3) uniform U_Material {

--- a/shaders/scene/skybox.frag
+++ b/shaders/scene/skybox.frag
@@ -26,7 +26,7 @@ layout(binding = 0) uniform samplerCube uTexSkybox;
 
 /* === Uniform Buffers === */
 
-layout(std140, binding = 1) uniform U_Environment {
+layout(std140, binding = 2) uniform U_Environment {
     Environment uEnv;
 };
 

--- a/shaders/scene/skybox.vert
+++ b/shaders/scene/skybox.vert
@@ -44,11 +44,11 @@ const int cubeIndices[36] = int[]
 
 /* === Uniform Buffers === */
 
-layout(std140, binding = 0) uniform U_ViewFrustum {
+layout(std140, binding = 1) uniform U_ViewFrustum {
     Frustum uFrustum;
 };
 
-layout(std140, binding = 1) uniform U_Environment {
+layout(std140, binding = 2) uniform U_Environment {
     Environment uEnv;
 };
 

--- a/source/Detail/GPU/Buffer.hpp
+++ b/source/Detail/GPU/Buffer.hpp
@@ -49,6 +49,9 @@ public:
     bool upload(const void* data) noexcept;                                     // Overwrite entire buffer content, keep current size
     bool upload(GLintptr offset, GLsizeiptr size, const void* data) noexcept;   // Overwrite part of the buffer at given offset
 
+    template<typename T>
+    bool uploadObject(const T& data) noexcept;                                  // Overwrite entire buffer from offset 0 with provided data (size = sizeof(T))
+
     /** Memory mapping */
     template <typename T>
     T* map(GLenum access = GL_MAP_WRITE_BIT) noexcept;
@@ -160,6 +163,13 @@ inline void Buffer::reserve(GLsizeiptr size, bool keepData) noexcept
     if (size > mSize) {
         realloc(size, keepData);
     }
+}
+
+template<typename T>
+inline bool Buffer::uploadObject(const T& data) noexcept
+{
+    static_assert(!std::is_pointer_v<T>, "Do not pass pointers to uploadObject<T>!");
+    return upload(0, sizeof(T), &data);
 }
 
 inline bool Buffer::upload(const void* data) noexcept

--- a/source/Detail/GPU/Program.hpp
+++ b/source/Detail/GPU/Program.hpp
@@ -42,6 +42,16 @@ public:
     Program(Program&& other) noexcept;
     Program& operator=(Program&& other) noexcept;
 
+    /** Returns '-1' on failure */
+    int getUniformBlockIndex(const char* name) const noexcept;
+
+    /** Returns size of the uniform block */
+    size_t getUniformBlockSize(int blockIndex) const noexcept;
+
+    /** Set uniform binding point */
+    void setUniformBlockBinding(int blockIndex, uint32_t blockBinding) noexcept;
+
+    /** Simple getters */
     bool isValid() const noexcept;
     GLuint id() const noexcept;
 
@@ -169,6 +179,33 @@ inline Program& Program::operator=(Program&& other) noexcept
         mUniformCache = std::move(other.mUniformCache);
     }
     return *this;
+}
+
+inline int Program::getUniformBlockIndex(const char* name) const noexcept
+{
+    GLuint blockIndex = glGetUniformBlockIndex(mID, name);
+    if (blockIndex == GL_INVALID_INDEX) {
+        glGetError(); // cleanup error
+        return -1;
+    }
+    return static_cast<int>(blockIndex);
+}
+
+inline size_t Program::getUniformBlockSize(int blockIndex) const noexcept
+{
+    SDL_assert(blockIndex >= 0);
+
+    GLint blockSize = 0;
+    glGetActiveUniformBlockiv(mID, blockIndex, GL_UNIFORM_BLOCK_DATA_SIZE, &blockSize);
+
+    return static_cast<int>(blockSize);
+}
+
+inline void Program::setUniformBlockBinding(int blockIndex, uint32_t blockBinding) noexcept
+{
+    SDL_assert(blockIndex >= 0);
+
+    glUniformBlockBinding(mID, blockIndex, blockBinding);
 }
 
 inline bool Program::isValid() const noexcept

--- a/source/Detail/GPU/Program.hpp
+++ b/source/Detail/GPU/Program.hpp
@@ -43,6 +43,9 @@ public:
     Program& operator=(Program&& other) noexcept;
 
     /** Returns '-1' on failure */
+    int getUniformLocation(const char* name) const noexcept;
+
+    /** Returns '-1' on failure */
     int getUniformBlockIndex(const char* name) const noexcept;
 
     /** Returns size of the uniform block */
@@ -179,6 +182,11 @@ inline Program& Program::operator=(Program&& other) noexcept
         mUniformCache = std::move(other.mUniformCache);
     }
     return *this;
+}
+
+inline int Program::getUniformLocation(const char* name) const noexcept
+{
+    return glGetUniformLocation(mID, name);
 }
 
 inline int Program::getUniformBlockIndex(const char* name) const noexcept

--- a/source/HP_Render.cpp
+++ b/source/HP_Render.cpp
@@ -1878,12 +1878,12 @@ void HP_SetMaterialShaderTexture(HP_MaterialShader* shader, int slot, const HP_T
     shader->setTexture(slot, texture ? &texture->gpuTexture() : nullptr);
 }
 
-void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data)
+void HP_UpdateStaticMaterialShaderBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data)
 {
     shader->updateStaticBuffer(offset, size, data);
 }
 
-void HP_UpdateDynamicMaterialBuffer(HP_MaterialShader* shader, size_t size, const void* data)
+void HP_UpdateDynamicMaterialShaderBuffer(HP_MaterialShader* shader, size_t size, const void* data)
 {
     shader->updateDynamicBuffer(size, data);
 }

--- a/source/HP_Render.cpp
+++ b/source/HP_Render.cpp
@@ -1873,6 +1873,11 @@ void HP_DestroyMaterialShader(HP_MaterialShader* shader)
     gRender->programs.destroyMaterialShader(shader);
 }
 
+void HP_SetMaterialShaderTexture(HP_MaterialShader* shader, int slot, const HP_Texture* texture)
+{
+    shader->setTexture(slot, texture ? &texture->gpuTexture() : nullptr);
+}
+
 void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data)
 {
     shader->updateStaticBuffer(offset, size, data);

--- a/source/HP_Render.cpp
+++ b/source/HP_Render.cpp
@@ -17,6 +17,7 @@
 #include "./Render/HP_Texture.hpp"
 #include "./Render/HP_Font.hpp"
 #include "./Detail/Helper.hpp"
+#include "Hyperion/HP_Core.h"
 
 /* === Texture - Public API === */
 
@@ -1835,6 +1836,7 @@ HP_Material HP_GetDefaultMaterial(void)
         .billboard = HP_BILLBOARD_DISABLED,
         .blend = HP_BLEND_OPAQUE,
         .cull = HP_CULL_BACK,
+        .shader = nullptr
     };
 }
 
@@ -1844,6 +1846,31 @@ void HP_DestroyMaterialResources(HP_Material* material)
     HP_DestroyTexture(material->emission.texture);
     HP_DestroyTexture(material->orm.texture);
     HP_DestroyTexture(material->normal.texture);
+}
+
+/* === MaterialShader - Public API === */
+
+HP_MaterialShader* HP_CreateMaterialShader(const char* vertCode, const char* fragCode)
+{
+    return gRender->programs.createMaterialShader(vertCode, fragCode);
+}
+
+HP_MaterialShader* HP_LoadMaterialShader(const char* vertFile, const char* fragFile)
+{
+    char* vertCode = vertFile ? HP_LoadFileText(vertFile) : nullptr;
+    char* fragCode = fragFile ? HP_LoadFileText(fragFile) : nullptr;
+
+    HP_MaterialShader* shader = gRender->programs.createMaterialShader(vertCode, fragCode);
+
+    SDL_free(vertCode);
+    SDL_free(fragCode);
+
+    return shader;
+}
+
+void HP_DestroyMaterialShader(HP_MaterialShader* shader)
+{
+    gRender->programs.destroyMaterialShader(shader);
 }
 
 /* === Mesh - Public API === */

--- a/source/HP_Render.cpp
+++ b/source/HP_Render.cpp
@@ -1873,6 +1873,16 @@ void HP_DestroyMaterialShader(HP_MaterialShader* shader)
     gRender->programs.destroyMaterialShader(shader);
 }
 
+void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data)
+{
+    shader->updateStaticBuffer(offset, size, data);
+}
+
+void HP_UpdateDynamicMaterialBuffer(HP_MaterialShader* shader, size_t size, const void* data)
+{
+    shader->updateDynamicBuffer(size, data);
+}
+
 /* === Mesh - Public API === */
 
 HP_Mesh* HP_CreateMesh(const HP_Vertex3D* vertices, int vCount, const uint32_t* indices, int iCount)

--- a/source/Render/Core/ProgramCache.cpp
+++ b/source/Render/Core/ProgramCache.cpp
@@ -120,30 +120,12 @@ gpu::Program& ProgramCache::lightCulling()
 
 gpu::Program& ProgramCache::prepass()
 {
-    if (mPrepass.isValid()) {
-        return mPrepass;
-    }
-
-    mPrepass = gpu::Program(
-        gpu::Shader(GL_VERTEX_SHADER, PREPASS_VERT),
-        gpu::Shader(GL_FRAGMENT_SHADER, PREPASS_FRAG)
-    );
-
-    return mPrepass;
+    return mMaterialShader.prepass();
 }
 
 gpu::Program& ProgramCache::forward()
 {
-    if (mForward.isValid()) {
-        return mForward;
-    }
-
-    mForward = gpu::Program(
-        gpu::Shader(GL_VERTEX_SHADER, FORWARD_VERT),
-        gpu::Shader(GL_FRAGMENT_SHADER, FORWARD_FRAG)
-    );
-
-    return mForward;
+    return mMaterialShader.forward();
 }
 
 gpu::Program& ProgramCache::skybox()
@@ -168,16 +150,7 @@ gpu::Program& ProgramCache::skybox()
 
 gpu::Program& ProgramCache::shadow()
 {
-    if (mShadow.isValid()) {
-        return mShadow;
-    }
-
-    mShadow = gpu::Program(
-        gpu::Shader(GL_VERTEX_SHADER, SHADOW_VERT),
-        gpu::Shader(GL_FRAGMENT_SHADER, SHADOW_FRAG)
-    );
-
-    return mShadow;
+    return mMaterialShader.shadow();
 }
 
 gpu::Program& ProgramCache::output(HP_Tonemap tonemap)

--- a/source/Render/Core/ProgramCache.cpp
+++ b/source/Render/Core/ProgramCache.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "./ProgramCache.hpp"
-#include "Hyperion/HP_Render.h"
 
 #include <shaders/screen.vert.h>
 #include <shaders/cube.vert.h>
@@ -18,14 +17,8 @@
 #include <shaders/cubemap_skybox.frag.h>
 
 #include <shaders/light_culling.comp.h>
-#include <shaders/prepass.vert.h>
-#include <shaders/prepass.frag.h>
-#include <shaders/forward.vert.h>
-#include <shaders/forward.frag.h>
 #include <shaders/skybox.vert.h>
 #include <shaders/skybox.frag.h>
-#include <shaders/shadow.vert.h>
-#include <shaders/shadow.frag.h>
 
 #include <shaders/bilateral_blur.frag.h>
 #include <shaders/downsampling.frag.h>
@@ -118,16 +111,6 @@ gpu::Program& ProgramCache::lightCulling()
     return mLightCulling;
 }
 
-gpu::Program& ProgramCache::prepass()
-{
-    return mMaterialShader.prepass();
-}
-
-gpu::Program& ProgramCache::forward()
-{
-    return mMaterialShader.forward();
-}
-
 gpu::Program& ProgramCache::skybox()
 {
     if (mSkybox.isValid()) {
@@ -146,11 +129,6 @@ gpu::Program& ProgramCache::skybox()
     );
 
     return mSkybox;
-}
-
-gpu::Program& ProgramCache::shadow()
-{
-    return mMaterialShader.shadow();
 }
 
 gpu::Program& ProgramCache::output(HP_Tonemap tonemap)

--- a/source/Render/Core/ProgramCache.hpp
+++ b/source/Render/Core/ProgramCache.hpp
@@ -13,6 +13,7 @@
 
 #include "../../Detail/GPU/Program.hpp"
 #include "../../Detail/GPU/Shader.hpp"
+#include "../HP_MaterialShader.hpp"
 
 namespace render {
 
@@ -57,11 +58,9 @@ private:
     gpu::Program mCubemapSkybox;
 
     /** Scene programs */
+    HP_MaterialShader mMaterialShader{};
     gpu::Program mLightCulling{};
-    gpu::Program mPrepass{};
-    gpu::Program mForward{};
     gpu::Program mSkybox{};
-    gpu::Program mShadow{};
 
     /** Scene post process programs */
     std::array<gpu::Program, HP_BLOOM_COUNT> mBloomPost{};

--- a/source/Render/Core/ProgramCache.hpp
+++ b/source/Render/Core/ProgramCache.hpp
@@ -28,6 +28,9 @@ public:
     HP_MaterialShader* createMaterialShader(const char* vert, const char* frag);
     void destroyMaterialShader(HP_MaterialShader* shader);
 
+    /** Should be called at the end of 'HP_End3D()' */
+    void clearDynamicMaterialBuffers();
+
     /** Cubemap generation */
     gpu::Program& cubemapFromEquirectangular();
     gpu::Program& cubemapIrradiance();
@@ -35,9 +38,7 @@ public:
     gpu::Program& cubemapSkybox();
 
     /** Scene programs */
-    gpu::Program& forward(HP_MaterialShader* shader);
-    gpu::Program& prepass(HP_MaterialShader* shader);
-    gpu::Program& shadow(HP_MaterialShader* shader);
+    HP_MaterialShader& materialShader(HP_MaterialShader* shader);
     gpu::Program& lightCulling();
     gpu::Program& skybox();
 
@@ -106,19 +107,16 @@ inline void ProgramCache::destroyMaterialShader(HP_MaterialShader* shader)
     mMaterialShaders.destroy(shader);
 }
 
-inline gpu::Program& ProgramCache::forward(HP_MaterialShader* shader)
+inline void ProgramCache::clearDynamicMaterialBuffers()
 {
-    return shader ? shader->forward() : mMaterialShader.forward();
+    for (HP_MaterialShader& shader : mMaterialShaders) {
+        shader.clearDynamicBuffer();
+    }
 }
 
-inline gpu::Program& ProgramCache::prepass(HP_MaterialShader* shader)
+inline HP_MaterialShader& ProgramCache::materialShader(HP_MaterialShader* shader)
 {
-    return shader ? shader->prepass() : mMaterialShader.prepass();
-}
-
-inline gpu::Program& ProgramCache::shadow(HP_MaterialShader* shader)
-{
-    return shader ? shader->shadow() : mMaterialShader.shadow();
+    return shader ? *shader : mMaterialShader;
 }
 
 } // namespace render

--- a/source/Render/HP_MaterialShader.cpp
+++ b/source/Render/HP_MaterialShader.cpp
@@ -1,0 +1,85 @@
+#include "./HP_MaterialShader.hpp"
+
+#include <shaders/forward.vert.h>
+#include <shaders/forward.frag.h>
+#include <shaders/prepass.vert.h>
+#include <shaders/prepass.frag.h>
+#include <shaders/shadow.vert.h>
+#include <shaders/shadow.frag.h>
+
+#include <string_view>
+
+/* === Public Implementation === */
+
+HP_MaterialShader::HP_MaterialShader()
+    : mForward(
+        gpu::Shader(GL_VERTEX_SHADER, FORWARD_VERT),
+        gpu::Shader(GL_FRAGMENT_SHADER, FORWARD_FRAG)
+    )
+    , mPrePass(
+        gpu::Shader(GL_VERTEX_SHADER, PREPASS_VERT),
+        gpu::Shader(GL_FRAGMENT_SHADER, PREPASS_FRAG)
+    )
+    , mShadow(
+        gpu::Shader(GL_VERTEX_SHADER, SHADOW_VERT),
+        gpu::Shader(GL_FRAGMENT_SHADER, SHADOW_FRAG)
+    )
+{ }
+
+HP_MaterialShader::HP_MaterialShader(const char* vert, const char* frag)
+{
+    /* --- Constants --- */
+
+    constexpr std::string_view vertDefine = "#define vertex()";
+    constexpr std::string_view fragDefine = "#define fragment()";
+
+    /* --- Load all base shaders --- */
+
+    std::string vertForward = FORWARD_VERT;
+    std::string fragForward = FORWARD_FRAG;
+    std::string vertPrepass = PREPASS_VERT;
+    std::string fragPrepass = PREPASS_FRAG;
+    std::string vertShadow = SHADOW_VERT;
+    std::string fragShadow = SHADOW_FRAG;
+
+    /* --- Process shaders --- */
+
+    processCode(vertForward, vertDefine, vert);
+    processCode(fragForward, fragDefine, frag);
+    processCode(vertForward, vertDefine, vert);
+    processCode(fragForward, fragDefine, frag);
+    processCode(vertForward, vertDefine, vert);
+    processCode(fragForward, fragDefine, frag);
+
+    /* --- Compile shaders --- */
+
+    mForward = gpu::Program(
+        gpu::Shader(GL_VERTEX_SHADER, vertForward.c_str()),
+        gpu::Shader(GL_FRAGMENT_SHADER, fragForward.c_str())
+    );
+
+    mPrePass = gpu::Program(
+        gpu::Shader(GL_VERTEX_SHADER, vertPrepass.c_str()),
+        gpu::Shader(GL_FRAGMENT_SHADER, fragPrepass.c_str())
+    );
+
+    mShadow = gpu::Program(
+        gpu::Shader(GL_VERTEX_SHADER, vertShadow.c_str()),
+        gpu::Shader(GL_FRAGMENT_SHADER, fragShadow.c_str())
+    );
+}
+
+/* === Private Implementation === */
+
+void HP_MaterialShader::processCode(std::string& source, const std::string_view& define, const char* code)
+{
+    if (code == nullptr) {
+        return;
+    }
+
+    size_t pos = source.find(define);
+
+    if (pos != std::string::npos) {
+        source.replace(pos, define.length(), code);
+    }
+}

--- a/source/Render/HP_MaterialShader.hpp
+++ b/source/Render/HP_MaterialShader.hpp
@@ -1,0 +1,44 @@
+#ifndef HP_RENDER_MATERIAL_SHADER_HPP
+#define HP_RENDER_MATERIAL_SHADER_HPP
+
+#include "../Detail/GPU/Program.hpp"
+
+/* === Declaration === */
+
+class HP_MaterialShader {
+public:
+    HP_MaterialShader();
+    HP_MaterialShader(const char* vertex, const char* fragment);
+
+    /** Getters */
+    gpu::Program& forward();
+    gpu::Program& prepass();
+    gpu::Program& shadow();
+
+private:
+    void processCode(std::string& source, const std::string_view& define, const char* code);
+
+private:
+    gpu::Program mForward;
+    gpu::Program mPrePass;
+    gpu::Program mShadow;
+};
+
+/* === Public Implementation === */
+
+inline gpu::Program& HP_MaterialShader::forward()
+{
+    return mForward;
+}
+
+inline gpu::Program& HP_MaterialShader::prepass()
+{
+    return mPrePass;
+}
+
+inline gpu::Program& HP_MaterialShader::shadow()
+{
+    return mShadow;
+}
+
+#endif // HP_RENDER_MATERIAL_SHADER_HPP

--- a/source/Render/HP_MaterialShader.hpp
+++ b/source/Render/HP_MaterialShader.hpp
@@ -1,44 +1,86 @@
 #ifndef HP_RENDER_MATERIAL_SHADER_HPP
 #define HP_RENDER_MATERIAL_SHADER_HPP
 
+#include "../Detail/Util/DynamicArray.hpp"
+#include "../Detail/GPU/Pipeline.hpp"
 #include "../Detail/GPU/Program.hpp"
+#include "../Detail/GPU/Buffer.hpp"
+
+#include <string_view>
+#include <array>
 
 /* === Declaration === */
 
 class HP_MaterialShader {
 public:
+    /** Helper enums */
+    enum Shader { FORWARD, PREPASS, SHADOW, SHADER_COUNT };
+    enum Uniform { STATIC_UNIFORM, DYNAMIC_UNIFORM, UNIFORM_COUNT };
+
+public:
     HP_MaterialShader();
     HP_MaterialShader(const char* vertex, const char* fragment);
 
+    /** Uniform buffer uploading functions */
+    void updateStaticBuffer(size_t offset, size_t size, const void* data);
+    void updateDynamicBuffer(size_t size, const void* data);
+
+    /** Buffer bindings */
+    void bindUniformBuffers(const gpu::Pipeline& pipeline, Shader shader, int dynamicRangeIndex);
+
+    /** Dynamic buffer management */
+    void clearDynamicBuffer();
+
     /** Getters */
-    gpu::Program& forward();
-    gpu::Program& prepass();
-    gpu::Program& shadow();
+    gpu::Program& program(Shader shader);
+    int dynamicRangeIndex() const;
 
 private:
+    /** Used at construction to generate final shader code */
     void processCode(std::string& source, const std::string_view& define, const char* code);
 
 private:
-    gpu::Program mForward;
-    gpu::Program mPrePass;
-    gpu::Program mShadow;
+    /** Built-in uniform block names */
+    static constexpr const char* UniformNames[UNIFORM_COUNT] = {
+        "StaticBuffer", "DynamicBuffer"
+    };
+
+    /** Built-in uniform block binding points */
+    static constexpr int UniformBinding[UNIFORM_COUNT] {
+        10, 11
+    };
+
+private:
+    struct DynamicBuffer {
+        struct Range { size_t offset, size; };
+        util::DynamicArray<Range> ranges{};
+        int currentRangeIndex{};
+        size_t currentOffset{};
+        gpu::Buffer buffer{};
+    };
+
+private:
+    std::array<gpu::Program, SHADER_COUNT> mPrograms{};
+    DynamicBuffer mDynamicBuffer{};
+    gpu::Buffer mStaticBuffer{};
 };
 
 /* === Public Implementation === */
 
-inline gpu::Program& HP_MaterialShader::forward()
+inline void HP_MaterialShader::clearDynamicBuffer()
 {
-    return mForward;
+    mDynamicBuffer.currentOffset = 0;
+    mDynamicBuffer.ranges.clear();
 }
 
-inline gpu::Program& HP_MaterialShader::prepass()
+inline gpu::Program& HP_MaterialShader::program(Shader shader)
 {
-    return mPrePass;
+    return mPrograms[shader];
 }
 
-inline gpu::Program& HP_MaterialShader::shadow()
+inline int HP_MaterialShader::dynamicRangeIndex() const
 {
-    return mShadow;
+    return mDynamicBuffer.currentRangeIndex;
 }
 
 #endif // HP_RENDER_MATERIAL_SHADER_HPP

--- a/source/Render/Scene/DrawCall.hpp
+++ b/source/Render/Scene/DrawCall.hpp
@@ -42,6 +42,7 @@ public:
     const HP_Mesh& mesh() const;
 
     /** External draw call data */
+    const HP_MaterialShader::TextureArray& materialShaderTextures() const;
     int dynamicRangeIndex() const;
     int drawDataIndex() const;
 
@@ -49,11 +50,14 @@ public:
     void draw(const gpu::Pipeline& pipeline, const HP_InstanceBuffer* instances, int instanceCount) const;
 
 private:
+    /** Object to draw */
     HP_Material mMaterial;
     const HP_Mesh& mMesh;
 
-    int mDynamicRangeIndex;     //< Index of the material shader's dynamic uniform buffer range (if any)
-    int mDrawDataIndex;         //< Index to shared drawing data (DrawData)
+    /** Additionnal data */
+    HP_MaterialShader::TextureArray mTextures;  //< Array containing the textures linked to the material shader at the time of draw (if any)
+    int mDynamicRangeIndex;                     //< Index of the material shader's dynamic uniform buffer range (if any)
+    int mDrawDataIndex;                         //< Index to shared drawing data (DrawData)
 };
 
 /* === Container === */
@@ -67,6 +71,7 @@ inline DrawCall::DrawCall(int dataIndex, const HP_Mesh& mesh, const HP_Material&
 {
     if (material.shader != nullptr) {
         mDynamicRangeIndex = material.shader->dynamicRangeIndex();
+        material.shader->getTextures(mTextures);
     }
 }
 
@@ -96,6 +101,11 @@ inline const HP_Material& DrawCall::material() const
 inline const HP_Mesh& DrawCall::mesh() const
 {
     return mMesh;
+}
+
+inline const HP_MaterialShader::TextureArray& DrawCall::materialShaderTextures() const
+{
+    return mTextures;
 }
 
 inline int DrawCall::dynamicRangeIndex() const

--- a/source/Render/Scene/LightManager.cpp
+++ b/source/Render/Scene/LightManager.cpp
@@ -312,7 +312,10 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
 
     const auto draw = [this, &params](const gpu::Pipeline& pipeline, const DrawCall& call, const DrawData& data)
     {
-        pipeline.useProgram(mPrograms.shadow(call.material().shader));
+        HP_MaterialShader& shader = mPrograms.materialShader(call.material().shader);
+
+        pipeline.useProgram(shader.program(HP_MaterialShader::SHADOW));
+        shader.bindUniformBuffers(pipeline, HP_MaterialShader::SHADOW, call.dynamicRangeIndex());
 
         const HP_Texture* texture = call.material().albedo.texture;
         pipeline.bindTexture(0, mAssets.textureOrWhite(texture));
@@ -400,8 +403,8 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
                     if (call.mesh().shadowCastMode == HP_SHADOW_CAST_DISABLED) continue;
                     if ((light.shadowCullMask() & call.mesh().layerMask) == 0) continue;
 
-                    if (!frustumCulling || light.isInsideShadowFrustum(call, params.drawData[call.dataIndex()])) {
-                        draw(pipeline, call, params.drawData[call.dataIndex()]);
+                    if (!frustumCulling || light.isInsideShadowFrustum(call, params.drawData[call.drawDataIndex()])) {
+                        draw(pipeline, call, params.drawData[call.drawDataIndex()]);
                     }
                 }
             }
@@ -426,8 +429,8 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
                     if (call.mesh().shadowCastMode == HP_SHADOW_CAST_DISABLED) continue;
                     if ((light.shadowCullMask() & call.mesh().layerMask) == 0) continue;
 
-                    if (!frustumCulling || light.isInsideShadowFrustum(call, params.drawData[call.dataIndex()])) {
-                        draw(pipeline, call, params.drawData[call.dataIndex()]);
+                    if (!frustumCulling || light.isInsideShadowFrustum(call, params.drawData[call.drawDataIndex()])) {
+                        draw(pipeline, call, params.drawData[call.drawDataIndex()]);
                     }
                 }
             }
@@ -457,8 +460,8 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
                         if (call.mesh().shadowCastMode == HP_SHADOW_CAST_DISABLED) continue;
                         if ((light.shadowCullMask() & call.mesh().layerMask) == 0) continue;
 
-                        if (!frustumCulling || light.isInsideShadowFrustum(call, params.drawData[call.dataIndex()], iFace)) {
-                            draw(pipeline, call, params.drawData[call.dataIndex()]);
+                        if (!frustumCulling || light.isInsideShadowFrustum(call, params.drawData[call.drawDataIndex()], iFace)) {
+                            draw(pipeline, call, params.drawData[call.drawDataIndex()]);
                         }
                     }
                 }

--- a/source/Render/Scene/LightManager.cpp
+++ b/source/Render/Scene/LightManager.cpp
@@ -315,15 +315,11 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
         const HP_Texture* texture = call.material().albedo.texture;
         pipeline.bindTexture(0, mAssets.textureOrWhite(texture));
 
-        pipeline.setUniformMat4(1, data.matrix());
-        pipeline.setUniformFloat2(2, call.material().texOffset);
-        pipeline.setUniformFloat2(3, call.material().texScale);
-        pipeline.setUniformFloat1(4, call.material().albedo.color.a);
-        pipeline.setUniformInt1(5, data.useSkinning());
-        pipeline.setUniformInt1(6, data.boneMatrixOffset());
-        pipeline.setUniformInt1(7, data.useInstancing());
-        pipeline.setUniformUint1(8, call.material().billboard);
-        pipeline.setUniformFloat1(11, call.material().alphaCutOff);
+        params.renderableBuffer.upload(data, call);
+        params.materialBuffer.upload(call.material());
+
+        pipeline.bindUniform(2, params.renderableBuffer.buffer());
+        pipeline.bindUniform(3, params.materialBuffer.buffer());
 
         switch (call.mesh().shadowFaceMode) {
         case HP_SHADOW_FACE_AUTO:
@@ -379,9 +375,9 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
             continue;
         }
 
-        pipeline.setUniformFloat3(10, light.position());
-        pipeline.setUniformFloat1(12, light.shadowLambda());
-        pipeline.setUniformFloat1(13, light.range());
+        pipeline.setUniformFloat3(1, light.position());
+        pipeline.setUniformFloat1(2, light.shadowLambda());
+        pipeline.setUniformFloat1(3, light.range());
 
         float rangeSq = HP_POW2(light.range());
 

--- a/source/Render/Scene/LightManager.cpp
+++ b/source/Render/Scene/LightManager.cpp
@@ -357,10 +357,8 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
 
     gpu::Pipeline pipeline;
 
-    pipeline.setDepthMode(gpu::DepthMode::TestAndWrite);
-    pipeline.setCullMode(gpu::CullMode::Back);
-
     pipeline.setViewport(0, 0, mShadowResolution, mShadowResolution);
+    pipeline.setDepthMode(gpu::DepthMode::TestAndWrite);
     pipeline.useProgram(mPrograms.shadow());
 
     /* --- Bind UBOs and SSBOs --- */

--- a/source/Render/Scene/LightManager.cpp
+++ b/source/Render/Scene/LightManager.cpp
@@ -316,6 +316,7 @@ void LightManager::renderShadowMaps(const ProcessParams& params)
 
         pipeline.useProgram(shader.program(HP_MaterialShader::SHADOW));
         shader.bindUniformBuffers(pipeline, HP_MaterialShader::SHADOW, call.dynamicRangeIndex());
+        shader.bindTextures(pipeline, call.materialShaderTextures(), mAssets.textureWhite().gpuTexture());
 
         const HP_Texture* texture = call.material().albedo.texture;
         pipeline.bindTexture(0, mAssets.textureOrWhite(texture));

--- a/source/Render/Scene/LightManager.hpp
+++ b/source/Render/Scene/LightManager.hpp
@@ -18,11 +18,13 @@
 #include "../Core/ProgramCache.hpp"
 #include "../Core/AssetCache.hpp"
 
+#include "./RenderableBuffer.hpp"
+#include "./MaterialBuffer.hpp"
 #include "./ViewFrustum.hpp"
+#include "./Environment.hpp"
 #include "./BoneBuffer.hpp"
 #include "../HP_Light.hpp"
 #include "./DrawCall.hpp"
-#include "Environment.hpp"
 
 namespace scene {
 
@@ -33,6 +35,8 @@ public:
     struct ProcessParams {
         const ViewFrustum& viewFrustum;
         const Environment& environment;
+        RenderableBuffer& renderableBuffer;
+        MaterialBuffer& materialBuffer;
         const BoneBuffer& boneBuffer;
         const BucketDrawCalls& drawCalls;
         const ArrayDrawData& drawData;

--- a/source/Render/Scene/LightManager.hpp
+++ b/source/Render/Scene/LightManager.hpp
@@ -10,6 +10,7 @@
 #define HP_SCENE_LIGHT_MANAGER_HPP
 
 #include <Hyperion/HP_Render.h>
+#include <Hyperion/HP_Core.h>
 
 #include "../../Detail/Util/ObjectPool.hpp"
 #include "../../Detail/GPU/Texture.hpp"
@@ -103,6 +104,7 @@ private:
             alignas(16) HP_Vec3 lightPosition;
             alignas(4) float shadowLambda;
             alignas(4) float farPlane;
+            alignas(4) float elapsedTime;
         };
         int mCurrentBuffer{};
         std::array<gpu::Buffer, 3> mBuffers{};
@@ -274,15 +276,26 @@ inline void LightManager::FrameShadowUniform::upload(const HP_Mat4& lightViewPro
         .lightViewProj = lightViewProj,
         .lightPosition = lightPosition,
         .shadowLambda = shadowLambda,
-        .farPlane = farPlane
+        .farPlane = farPlane,
+        .elapsedTime = static_cast<float>(HP_GetElapsedTime())
     });
 }
 
 inline void LightManager::FrameShadowUniform::upload(const HP_Vec3& lightPosition, float shadowLambda, float farPlane)
 {
     for (gpu::Buffer& buffer : mBuffers) {
-        Uniform data { .lightViewProj = {}, .lightPosition = lightPosition, .shadowLambda = shadowLambda, .farPlane = farPlane };
-        buffer.upload(offsetof(Uniform, lightViewProj), sizeof(Uniform) - offsetof(Uniform, lightViewProj), &data.lightPosition);
+        Uniform data {
+            .lightViewProj = {},
+            .lightPosition = lightPosition,
+            .shadowLambda = shadowLambda,
+            .farPlane = farPlane,
+            .elapsedTime = static_cast<float>(HP_GetElapsedTime())
+        };
+        buffer.upload(
+            offsetof(Uniform, lightViewProj),
+            sizeof(Uniform) - offsetof(Uniform, lightViewProj),
+            &data.lightPosition
+        );
     }
 }
 

--- a/source/Render/Scene/RenderableBuffer.hpp
+++ b/source/Render/Scene/RenderableBuffer.hpp
@@ -34,7 +34,6 @@ private:
         alignas(4) uint32_t layerMask;
         alignas(4) int32_t instancing;
         alignas(4) int32_t skinning;
-        alignas(4) float time;
     };
 
 private:
@@ -60,7 +59,6 @@ inline void RenderableBuffer::upload(const DrawData& data, const DrawCall& call)
         .layerMask = call.mesh().layerMask,
         .instancing = data.useInstancing(),
         .skinning = data.useSkinning(),
-        .time = static_cast<float>(HP_GetElapsedTime())
     };
 
     mBufferIndex = (mBufferIndex + 1) % mBuffers.size();

--- a/source/Render/Scene/RenderableBuffer.hpp
+++ b/source/Render/Scene/RenderableBuffer.hpp
@@ -9,7 +9,9 @@
 #ifndef HP_SCENE_RENDERABLE_BUFFER_HPP
 #define HP_SCENE_RENDERABLE_BUFFER_HPP
 
+#include <Hyperion/HP_Core.h>
 #include <Hyperion/HP_Math.h>
+
 #include "./DrawData.hpp"
 #include "./DrawCall.hpp"
 
@@ -32,6 +34,7 @@ private:
         alignas(4) uint32_t layerMask;
         alignas(4) int32_t instancing;
         alignas(4) int32_t skinning;
+        alignas(4) float time;
     };
 
 private:
@@ -56,7 +59,8 @@ inline void RenderableBuffer::upload(const DrawData& data, const DrawCall& call)
         .boneOffset = data.boneMatrixOffset(),
         .layerMask = call.mesh().layerMask,
         .instancing = data.useInstancing(),
-        .skinning = data.useSkinning()
+        .skinning = data.useSkinning(),
+        .time = static_cast<float>(HP_GetElapsedTime())
     };
 
     mBufferIndex = (mBufferIndex + 1) % mBuffers.size();

--- a/source/Render/Scene/Scene.cpp
+++ b/source/Render/Scene/Scene.cpp
@@ -275,6 +275,7 @@ void Scene::renderPrePass(const gpu::Pipeline& pipeline)
         HP_MaterialShader& shader = mPrograms.materialShader(mat.shader);
         pipeline.useProgram(shader.program(HP_MaterialShader::PREPASS));
         shader.bindUniformBuffers(pipeline, HP_MaterialShader::PREPASS, call.dynamicRangeIndex());
+        shader.bindTextures(pipeline, call.materialShaderTextures(), mAssets.textureWhite().gpuTexture());
 
         switch (mat.depth.test) {
         case HP_DEPTH_TEST_LESS:
@@ -347,6 +348,7 @@ void Scene::renderScene(const gpu::Pipeline& pipeline)
         HP_MaterialShader& shader = mPrograms.materialShader(mat.shader);
         pipeline.useProgram(shader.program(HP_MaterialShader::FORWARD));
         shader.bindUniformBuffers(pipeline, HP_MaterialShader::FORWARD, call.dynamicRangeIndex());
+        shader.bindTextures(pipeline, call.materialShaderTextures(), mAssets.textureWhite().gpuTexture());
 
         if (mat.depth.prePass) {
             pipeline.setDepthFunc(gpu::DepthFunc::Equal);

--- a/source/Render/Scene/Scene.cpp
+++ b/source/Render/Scene/Scene.cpp
@@ -129,6 +129,8 @@ void Scene::end()
     mLights.process({
         .viewFrustum = mFrustum,
         .environment = mEnvironment,
+        .renderableBuffer = mRenderableBuffer,
+        .materialBuffer = mMaterialBuffer,
         .boneBuffer = mBoneBuffer,
         .drawCalls = mDrawCalls,
         .drawData = mDrawData

--- a/source/Render/Scene/Scene.hpp
+++ b/source/Render/Scene/Scene.hpp
@@ -67,6 +67,17 @@ private:
         float aspect{};
     };
 
+    struct FrameUniform {
+        alignas(8) HP_IVec2 screenSize;
+        alignas(16) HP_IVec3 clusterCount;
+        alignas(4) uint32_t maxLightsPerCluster;
+        alignas(4) float clusterSliceScale;
+        alignas(4) float clusterSliceBias;
+        alignas(4) float elapsedTime;
+        alignas(4) int32_t hasActiveLights;
+        alignas(4) int32_t hasProbe;
+    };
+
 private:
     /** Shared assets */
     render::ProgramCache& mPrograms;
@@ -98,6 +109,9 @@ private:
     /** Swap buffers */
     gpu::SwapBuffer mSwapPostProcess{};     //< Ping-pong buffer used during scene post process
     gpu::SwapBuffer mSwapAuxiliary{};       //< Secondary ping-pong buffer in half resolution
+
+    /** Uniform buffers */
+    gpu::Buffer mFrameUniform;
 
     /** State infos */
     TargetInfo mTargetInfo{};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ function(add_hyperion_test test_name source_file)
 endfunction()
 
 add_hyperion_test("hp-skybox-procedural" "${HP_ROOT_PATH}/tests/skybox_procedural.c")
+add_hyperion_test("hp-material-shader" "${HP_ROOT_PATH}/tests/material_shader.c")
 add_hyperion_test("hp-render-texture" "${HP_ROOT_PATH}/tests/render_texture.c")
 add_hyperion_test("hp-animation" "${HP_ROOT_PATH}/tests/animation.c")
 add_hyperion_test("hp-instanced" "${HP_ROOT_PATH}/tests/instanced.c")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ function(add_hyperion_test test_name source_file)
     endif()
 endfunction()
 
+add_hyperion_test("hp-instanced-material-shader" "${HP_ROOT_PATH}/tests/instanced_material_shader.c")
 add_hyperion_test("hp-skybox-procedural" "${HP_ROOT_PATH}/tests/skybox_procedural.c")
 add_hyperion_test("hp-material-shader" "${HP_ROOT_PATH}/tests/material_shader.c")
 add_hyperion_test("hp-render-texture" "${HP_ROOT_PATH}/tests/render_texture.c")

--- a/tests/instanced_material_shader.c
+++ b/tests/instanced_material_shader.c
@@ -1,0 +1,68 @@
+#include <Hyperion/Hyperion.h>
+#include "./common.h"
+
+#define X_INSTANCES 100
+#define Z_INSTANCES 100
+
+#define NUM_INSTANCES X_INSTANCES * Z_INSTANCES
+
+static HP_Mat4 iMatrices[NUM_INSTANCES];
+static HP_Color iColors[NUM_INSTANCES];
+static HP_Vec4 iData[NUM_INSTANCES];
+
+int main(void)
+{
+    HP_Init("Hyperion - Instanced Material Shader", 800, 450, HP_FLAG_VSYNC_HINT);
+    HP_AddSearchPath(RESOURCES_PATH, false);
+
+    HP_MaterialShader* shader = HP_LoadMaterialShader(
+        "shaders/instanced_material.vert",
+        "shaders/instanced_material.frag"
+    );
+
+    HP_Mesh* cube = HP_GenMeshCube(HP_VEC3_ONE, HP_VEC3_ONE);
+    HP_Material material = HP_GetDefaultMaterial();
+    material.emission.energy = 1.0f;
+    material.shader = shader;
+
+    HP_InstanceBuffer* instances = HP_CreateInstanceBuffer(
+        HP_INSTANCE_DATA_MATRIX | HP_INSTANCE_DATA_COLOR | HP_INSTANCE_DATA_CUSTOM,
+        NUM_INSTANCES
+    );
+
+    for (int z = 0, i = 0; z < Z_INSTANCES; z++) {
+        for (int x = 0; x < X_INSTANCES; x++, i++)
+        {
+            float px = HP_Remap(x, 0, X_INSTANCES, -100, 100);
+            float pz = HP_Remap(z, 0, Z_INSTANCES, -100, 100);
+
+            iMatrices[i] = HP_Mat4Translate(HP_VEC3(px, 0, pz));
+            iColors[i] = HP_ColorFromHSV(HP_Wrap(i, 0, 360), 1, 1, 1);
+            iData[i] = HP_VEC4(10.0f * HP_RandFloat(NULL), 100.0f * HP_RandFloat(NULL), 0, 0);
+        }
+    }
+
+    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_MATRIX, iMatrices, 0, NUM_INSTANCES, false);
+    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_COLOR, iColors, 0, NUM_INSTANCES, false);
+    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_CUSTOM, iData, 0, NUM_INSTANCES, false);
+
+    HP_Camera camera = HP_GetDefaultCamera();
+    HP_Environment env = HP_GetDefaultEnvironment();
+    env.bloom.mode = HP_BLOOM_MIX;
+    env.bloom.strength = 0.1f;
+    env.background = HP_BLACK;
+    env.ambient = HP_BLACK;
+
+    while (HP_FrameStep())
+    {
+        CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 2.0f, 1.0f);
+
+        HP_Begin3D(&camera, &env, NULL);
+        HP_DrawMeshInstanced3D(cube, instances, NUM_INSTANCES, &material, NULL);
+        HP_End3D();
+    }
+
+    HP_Quit();
+
+    return 0;
+}

--- a/tests/material_shader.c
+++ b/tests/material_shader.c
@@ -1,6 +1,17 @@
 #include <Hyperion/Hyperion.h>
 #include "./common.h"
+#include "Hyperion/HP_Math.h"
+#include "Hyperion/HP_Rand.h"
 #include "Hyperion/HP_Render.h"
+
+#define X_INSTANCES 100
+#define Z_INSTANCES 100
+
+#define NUM_INSTANCES X_INSTANCES * Z_INSTANCES
+
+static HP_Mat4 iMatrices[NUM_INSTANCES];
+static HP_Color iColors[NUM_INSTANCES];
+static HP_Vec4 iData[NUM_INSTANCES];
 
 int main(void)
 {
@@ -14,13 +25,34 @@ int main(void)
 
     HP_Mesh* cube = HP_GenMeshCube(HP_VEC3_ONE, HP_VEC3_ONE);
     HP_Material material = HP_GetDefaultMaterial();
-    material.emission.color = HP_RED;
-    material.emission.energy = 10.0f;
+    material.emission.energy = 1.0f;
     material.shader = shader;
+
+    HP_InstanceBuffer* instances = HP_CreateInstanceBuffer(
+        HP_INSTANCE_DATA_MATRIX | HP_INSTANCE_DATA_COLOR | HP_INSTANCE_DATA_CUSTOM,
+        NUM_INSTANCES
+    );
+
+    for (int z = 0, i = 0; z < Z_INSTANCES; z++) {
+        for (int x = 0; x < X_INSTANCES; x++, i++)
+        {
+            float px = HP_Remap(x, 0, X_INSTANCES, -100, 100);
+            float pz = HP_Remap(z, 0, Z_INSTANCES, -100, 100);
+
+            iMatrices[i] = HP_Mat4Translate(HP_VEC3(px, 0, pz));
+            iColors[i] = HP_ColorFromHSV(HP_Wrap(i, 0, 360), 1, 1, 1);
+            iData[i] = HP_VEC4(10.0f * HP_RandFloat(NULL), 100.0f * HP_RandFloat(NULL), 0, 0);
+        }
+    }
+
+    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_MATRIX, iMatrices, 0, NUM_INSTANCES, false);
+    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_COLOR, iColors, 0, NUM_INSTANCES, false);
+    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_CUSTOM, iData, 0, NUM_INSTANCES, false);
 
     HP_Camera camera = HP_GetDefaultCamera();
     HP_Environment env = HP_GetDefaultEnvironment();
     env.bloom.mode = HP_BLOOM_MIX;
+    env.bloom.strength = 0.1f;
     env.background = HP_BLACK;
     env.ambient = HP_BLACK;
 
@@ -29,7 +61,7 @@ int main(void)
         CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 2.0f, 1.0f);
 
         HP_Begin3D(&camera, &env, NULL);
-        HP_DrawMesh3D(cube, &material, NULL);
+        HP_DrawMeshInstanced3D(cube, instances, NUM_INSTANCES, &material, NULL);
         HP_End3D();
     }
 

--- a/tests/material_shader.c
+++ b/tests/material_shader.c
@@ -8,14 +8,23 @@ int main(void)
 
     HP_MaterialShader* shader = HP_LoadMaterialShader("shaders/material.vert", "shaders/material.frag");
 
+    HP_Image im0 = HP_GenImageChecked(64, 64, 8, 8, HP_WHITE, HP_BLANK);
+    HP_Texture* tex0 = HP_CreateTexture(&im0);
+    HP_DestroyImage(&im0);
+
+    HP_Image im1 = HP_GenImageGradientSquare(64, 64, 0.8f, HP_WHITE, HP_BLANK);
+    HP_Texture* tex1 = HP_CreateTexture(&im1);
+    HP_DestroyImage(&im1);
+
     HP_Mesh* cube = HP_GenMeshCube(HP_VEC3_ONE, HP_VEC3_ONE);
     HP_Material material = HP_GetDefaultMaterial();
     material.shader = shader;
 
     HP_Camera camera = HP_GetDefaultCamera();
     HP_Environment env = HP_GetDefaultEnvironment();
-    //env.background = HP_BLACK;
-    //env.ambient = HP_BLACK;
+    env.bloom.mode = HP_BLOOM_ADDITIVE;
+    env.bloom.strength = 0.01f;
+    env.background = HP_BLACK;
 
     while (HP_FrameStep())
     {
@@ -23,7 +32,7 @@ int main(void)
             1.5f + sinf(4.0f * HP_GetElapsedTime()) * 0.5f, 0.0f, 0.0f, 0.0f
         ));
 
-        CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 4.0f, 2.0f);
+        CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 8.0f, 4.0f);
 
         HP_Begin3D(&camera, &env, NULL);
         {
@@ -31,12 +40,14 @@ int main(void)
 
             HP_Color c0 = HP_ColorFromHSV(90.0 * HP_GetElapsedTime(), 1, 1, 1);
             HP_UpdateDynamicMaterialBuffer(shader, sizeof(HP_Color), &c0);
+            HP_SetMaterialShaderTexture(shader, 0, tex0);
 
             T.translation.x = -1.5f;
             HP_DrawMesh3D(cube, &material, &T);
 
             HP_Color c1 = HP_ColorFromHSV(90.0 * HP_GetElapsedTime() + 90.0f, 1, 1, 1);
             HP_UpdateDynamicMaterialBuffer(shader, sizeof(HP_Color), &c1);
+            HP_SetMaterialShaderTexture(shader, 0, tex1);
 
             T.translation.x = +1.5f;
             HP_DrawMesh3D(cube, &material, &T);

--- a/tests/material_shader.c
+++ b/tests/material_shader.c
@@ -1,0 +1,39 @@
+#include <Hyperion/Hyperion.h>
+#include "./common.h"
+#include "Hyperion/HP_Render.h"
+
+int main(void)
+{
+    HP_Init("Hyperion - Skybox", 800, 450, HP_FLAG_VSYNC_HINT);
+    HP_AddSearchPath(RESOURCES_PATH, false);
+
+    HP_MaterialShader* shader = HP_LoadMaterialShader(
+        "shaders/material.vert",
+        "shaders/material.frag"
+    );
+
+    HP_Mesh* cube = HP_GenMeshCube(HP_VEC3_ONE, HP_VEC3_ONE);
+    HP_Material material = HP_GetDefaultMaterial();
+    material.emission.color = HP_RED;
+    material.emission.energy = 10.0f;
+    material.shader = shader;
+
+    HP_Camera camera = HP_GetDefaultCamera();
+    HP_Environment env = HP_GetDefaultEnvironment();
+    env.bloom.mode = HP_BLOOM_MIX;
+    env.background = HP_BLACK;
+    env.ambient = HP_BLACK;
+
+    while (HP_FrameStep())
+    {
+        CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 2.0f, 1.0f);
+
+        HP_Begin3D(&camera, &env, NULL);
+        HP_DrawMesh3D(cube, &material, NULL);
+        HP_End3D();
+    }
+
+    HP_Quit();
+
+    return 0;
+}

--- a/tests/material_shader.c
+++ b/tests/material_shader.c
@@ -1,8 +1,5 @@
 #include <Hyperion/Hyperion.h>
 #include "./common.h"
-#include "Hyperion/HP_Math.h"
-#include "Hyperion/HP_Rand.h"
-#include "Hyperion/HP_Render.h"
 
 #define X_INSTANCES 100
 #define Z_INSTANCES 100

--- a/tests/material_shader.c
+++ b/tests/material_shader.c
@@ -28,7 +28,7 @@ int main(void)
 
     while (HP_FrameStep())
     {
-        HP_UpdateStaticMaterialBuffer(shader, 0, sizeof(HP_Vec4), &HP_VEC4(
+        HP_UpdateStaticMaterialShaderBuffer(shader, 0, sizeof(HP_Vec4), &HP_VEC4(
             1.5f + sinf(4.0f * HP_GetElapsedTime()) * 0.5f, 0.0f, 0.0f, 0.0f
         ));
 
@@ -39,14 +39,14 @@ int main(void)
             HP_Transform T = HP_TRANSFORM_IDENTITY;
 
             HP_Color c0 = HP_ColorFromHSV(90.0 * HP_GetElapsedTime(), 1, 1, 1);
-            HP_UpdateDynamicMaterialBuffer(shader, sizeof(HP_Color), &c0);
+            HP_UpdateDynamicMaterialShaderBuffer(shader, sizeof(HP_Color), &c0);
             HP_SetMaterialShaderTexture(shader, 0, tex0);
 
             T.translation.x = -1.5f;
             HP_DrawMesh3D(cube, &material, &T);
 
             HP_Color c1 = HP_ColorFromHSV(90.0 * HP_GetElapsedTime() + 90.0f, 1, 1, 1);
-            HP_UpdateDynamicMaterialBuffer(shader, sizeof(HP_Color), &c1);
+            HP_UpdateDynamicMaterialShaderBuffer(shader, sizeof(HP_Color), &c1);
             HP_SetMaterialShaderTexture(shader, 0, tex1);
 
             T.translation.x = +1.5f;

--- a/tests/material_shader.c
+++ b/tests/material_shader.c
@@ -1,64 +1,46 @@
 #include <Hyperion/Hyperion.h>
 #include "./common.h"
 
-#define X_INSTANCES 100
-#define Z_INSTANCES 100
-
-#define NUM_INSTANCES X_INSTANCES * Z_INSTANCES
-
-static HP_Mat4 iMatrices[NUM_INSTANCES];
-static HP_Color iColors[NUM_INSTANCES];
-static HP_Vec4 iData[NUM_INSTANCES];
-
 int main(void)
 {
-    HP_Init("Hyperion - Skybox", 800, 450, HP_FLAG_VSYNC_HINT);
+    HP_Init("Hyperion - Material Shader", 800, 450, HP_FLAG_VSYNC_HINT);
     HP_AddSearchPath(RESOURCES_PATH, false);
 
-    HP_MaterialShader* shader = HP_LoadMaterialShader(
-        "shaders/material.vert",
-        "shaders/material.frag"
-    );
+    HP_MaterialShader* shader = HP_LoadMaterialShader("shaders/material.vert", "shaders/material.frag");
 
     HP_Mesh* cube = HP_GenMeshCube(HP_VEC3_ONE, HP_VEC3_ONE);
     HP_Material material = HP_GetDefaultMaterial();
-    material.emission.energy = 1.0f;
     material.shader = shader;
-
-    HP_InstanceBuffer* instances = HP_CreateInstanceBuffer(
-        HP_INSTANCE_DATA_MATRIX | HP_INSTANCE_DATA_COLOR | HP_INSTANCE_DATA_CUSTOM,
-        NUM_INSTANCES
-    );
-
-    for (int z = 0, i = 0; z < Z_INSTANCES; z++) {
-        for (int x = 0; x < X_INSTANCES; x++, i++)
-        {
-            float px = HP_Remap(x, 0, X_INSTANCES, -100, 100);
-            float pz = HP_Remap(z, 0, Z_INSTANCES, -100, 100);
-
-            iMatrices[i] = HP_Mat4Translate(HP_VEC3(px, 0, pz));
-            iColors[i] = HP_ColorFromHSV(HP_Wrap(i, 0, 360), 1, 1, 1);
-            iData[i] = HP_VEC4(10.0f * HP_RandFloat(NULL), 100.0f * HP_RandFloat(NULL), 0, 0);
-        }
-    }
-
-    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_MATRIX, iMatrices, 0, NUM_INSTANCES, false);
-    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_COLOR, iColors, 0, NUM_INSTANCES, false);
-    HP_UpdateInstanceBuffer(instances, HP_INSTANCE_DATA_CUSTOM, iData, 0, NUM_INSTANCES, false);
 
     HP_Camera camera = HP_GetDefaultCamera();
     HP_Environment env = HP_GetDefaultEnvironment();
-    env.bloom.mode = HP_BLOOM_MIX;
-    env.bloom.strength = 0.1f;
-    env.background = HP_BLACK;
-    env.ambient = HP_BLACK;
+    //env.background = HP_BLACK;
+    //env.ambient = HP_BLACK;
 
     while (HP_FrameStep())
     {
-        CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 2.0f, 1.0f);
+        HP_UpdateStaticMaterialBuffer(shader, 0, sizeof(HP_Vec4), &HP_VEC4(
+            1.5f + sinf(4.0f * HP_GetElapsedTime()) * 0.5f, 0.0f, 0.0f, 0.0f
+        ));
+
+        CMN_UpdateCamera(&camera, HP_VEC3_ZERO, 4.0f, 2.0f);
 
         HP_Begin3D(&camera, &env, NULL);
-        HP_DrawMeshInstanced3D(cube, instances, NUM_INSTANCES, &material, NULL);
+        {
+            HP_Transform T = HP_TRANSFORM_IDENTITY;
+
+            HP_Color c0 = HP_ColorFromHSV(90.0 * HP_GetElapsedTime(), 1, 1, 1);
+            HP_UpdateDynamicMaterialBuffer(shader, sizeof(HP_Color), &c0);
+
+            T.translation.x = -1.5f;
+            HP_DrawMesh3D(cube, &material, &T);
+
+            HP_Color c1 = HP_ColorFromHSV(90.0 * HP_GetElapsedTime() + 90.0f, 1, 1, 1);
+            HP_UpdateDynamicMaterialBuffer(shader, sizeof(HP_Color), &c1);
+
+            T.translation.x = +1.5f;
+            HP_DrawMesh3D(cube, &material, &T);
+        }
         HP_End3D();
     }
 

--- a/tests/resources/shaders/instanced_material.frag
+++ b/tests/resources/shaders/instanced_material.frag
@@ -1,0 +1,60 @@
+// Material fragment shader for 'instanced_material_shader.c'
+
+in flat uint vEffectIndex;
+
+float hash(vec2 p)
+{
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float sinPattern(vec2 p, float frequency)
+{
+    return 0.5 + 0.5 * sin((p.x + p.y) * frequency);
+}
+
+float checker(vec2 p, float size)
+{
+    vec2 q = floor(p / size);
+    return mod(q.x + q.y, 2.0);
+}
+
+float radial(vec2 p)
+{
+    vec2 c = vec2(0.5);
+    float d = distance(p, c);
+    return 1.0 - smoothstep(0.0, 0.5, d);
+}
+
+float effect(vec2 p)
+{
+    switch (vEffectIndex) {
+    case 0: {
+        const float pixelSize = 4.0;
+        vec2 pp = floor(p * 100.0 / pixelSize) * pixelSize;
+        return hash(pp + 0.0001 * TIME);
+    }
+    case 1: {
+        return hash(p + 0.0001 * TIME);
+    }
+    case 2: {
+        return sinPattern(p, 20.0);
+    }
+    case 3: {
+        return checker(p * 100.0, 8.0);
+    }
+    case 4: {
+        float v = radial(p);
+        v = max(v, 1.0 - v);
+        return v * v;
+    }
+    default:
+        break;
+    }
+
+    return 1.0;
+}
+
+void fragment()
+{
+    EMISSION *= ALBEDO.rgb * effect(TEXCOORD);
+}

--- a/tests/resources/shaders/instanced_material.vert
+++ b/tests/resources/shaders/instanced_material.vert
@@ -1,0 +1,10 @@
+// Material vertex shader for 'instanced_material_shader.c'
+
+out flat uint vEffectIndex;
+
+void vertex()
+{
+    float scale = 0.5 + sin(M_PI * TIME + INSTANCE_DATA.y) * 0.5;
+    vEffectIndex = uint(INSTANCE_DATA.x) % 5;
+    POSITION *= 0.5 + scale;
+}

--- a/tests/resources/shaders/material.frag
+++ b/tests/resources/shaders/material.frag
@@ -4,7 +4,11 @@ layout(std140) uniform DynamicBuffer {
     vec4 u_color;
 };
 
+uniform sampler2D Texture0;
+
 void fragment()
 {
     ALBEDO *= u_color;
+    EMISSION = texture(Texture0, TEXCOORD).rgb;
+    EMISSION *= ALBEDO.rgb;
 }

--- a/tests/resources/shaders/material.frag
+++ b/tests/resources/shaders/material.frag
@@ -1,0 +1,40 @@
+// Material fragment shader test
+
+float fade(float t)
+{
+    return t * t * (3.0 - 2.0 * t);
+}
+
+vec2 fade(vec2 t)
+{
+    return vec2(fade(t.x), fade(t.y));
+}
+
+float hash(vec2 p)
+{
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
+}
+
+float noise(vec2 p)
+{
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+
+    vec2 u = fade(f);
+
+    return mix(
+        mix(a, b, u.x),
+        mix(c, d, u.x),
+        u.y
+    );
+}
+
+void fragment()
+{
+    EMISSION *= 0.1 * noise(100.0 * vTexCoord);
+}

--- a/tests/resources/shaders/material.frag
+++ b/tests/resources/shaders/material.frag
@@ -36,5 +36,5 @@ float noise(vec2 p)
 
 void fragment()
 {
-    EMISSION *= 0.1 * noise(100.0 * vTexCoord);
+    EMISSION *= noise(100.0 * vTexCoord + 10.0 * vec2(TIME, -TIME));
 }

--- a/tests/resources/shaders/material.frag
+++ b/tests/resources/shaders/material.frag
@@ -43,7 +43,9 @@ float effect(vec2 p)
         return checker(p * 100.0, 8.0);
     }
     case 4: {
-        return radial(p);
+        float v = radial(p);
+        v = max(v, 1.0 - v);
+        return v * v;
     }
     default:
         break;
@@ -54,5 +56,5 @@ float effect(vec2 p)
 
 void fragment()
 {
-    EMISSION *= ALBEDO.rgb * effect(vTexCoord);
+    EMISSION *= ALBEDO.rgb * effect(TEXCOORD);
 }

--- a/tests/resources/shaders/material.frag
+++ b/tests/resources/shaders/material.frag
@@ -1,60 +1,10 @@
-// Material fragment shader test
+// Material fragment shader for 'material_shader.c'
 
-in flat uint vEffectIndex;
-
-float hash(vec2 p)
-{
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
-}
-
-float sinPattern(vec2 p, float frequency)
-{
-    return 0.5 + 0.5 * sin((p.x + p.y) * frequency);
-}
-
-float checker(vec2 p, float size)
-{
-    vec2 q = floor(p / size);
-    return mod(q.x + q.y, 2.0);
-}
-
-float radial(vec2 p)
-{
-    vec2 c = vec2(0.5);
-    float d = distance(p, c);
-    return 1.0 - smoothstep(0.0, 0.5, d);
-}
-
-float effect(vec2 p)
-{
-    switch (vEffectIndex) {
-    case 0: {
-        const float pixelSize = 4.0;
-        vec2 pp = floor(p * 100.0 / pixelSize) * pixelSize;
-        return hash(pp + 0.0001 * TIME);
-    }
-    case 1: {
-        return hash(p + 0.0001 * TIME);
-    }
-    case 2: {
-        return sinPattern(p, 20.0);
-    }
-    case 3: {
-        return checker(p * 100.0, 8.0);
-    }
-    case 4: {
-        float v = radial(p);
-        v = max(v, 1.0 - v);
-        return v * v;
-    }
-    default:
-        break;
-    }
-
-    return 1.0;
-}
+layout(std140) uniform DynamicBuffer {
+    vec4 u_color;
+};
 
 void fragment()
 {
-    EMISSION *= ALBEDO.rgb * effect(TEXCOORD);
+    ALBEDO *= u_color;
 }

--- a/tests/resources/shaders/material.vert
+++ b/tests/resources/shaders/material.vert
@@ -1,6 +1,10 @@
 // Material vertex shader test
 
+out flat uint vEffectIndex;
+
 void vertex()
 {
-
+    float scale = 0.5 + sin(M_PI * TIME + INSTANCE_DATA.y) * 0.5;
+    vEffectIndex = uint(INSTANCE_DATA.x) % 4;
+    POSITION *= 0.5 + scale;
 }

--- a/tests/resources/shaders/material.vert
+++ b/tests/resources/shaders/material.vert
@@ -1,0 +1,6 @@
+// Material vertex shader test
+
+void vertex()
+{
+
+}

--- a/tests/resources/shaders/material.vert
+++ b/tests/resources/shaders/material.vert
@@ -5,6 +5,6 @@ out flat uint vEffectIndex;
 void vertex()
 {
     float scale = 0.5 + sin(M_PI * TIME + INSTANCE_DATA.y) * 0.5;
-    vEffectIndex = uint(INSTANCE_DATA.x) % 4;
+    vEffectIndex = uint(INSTANCE_DATA.x) % 5;
     POSITION *= 0.5 + scale;
 }

--- a/tests/resources/shaders/material.vert
+++ b/tests/resources/shaders/material.vert
@@ -1,10 +1,10 @@
-// Material vertex shader test
+// Material vertex shader for 'material_shader.c'
 
-out flat uint vEffectIndex;
+layout(std140) uniform StaticBuffer {
+    float u_scale;
+};
 
 void vertex()
 {
-    float scale = 0.5 + sin(M_PI * TIME + INSTANCE_DATA.y) * 0.5;
-    vEffectIndex = uint(INSTANCE_DATA.x) % 5;
-    POSITION *= 0.5 + scale;
+    POSITION *= u_scale;
 }


### PR DESCRIPTION
This PR adds a custom material shader system to Hyperion, it lets you tweak the default material pipeline for vertex and fragment stages.

#### What's New

1. **Vertex and Fragment Overrides**

   * You can optionally provide a `vertex()` and/or `fragment()` function in GLSL.
   * The vertex stage runs after the material is set up and matrices are computed (model/normal) but before the vertices are transformed, so you can tweak positions, colors, normals, tangents, etc, whatever you need.
   * The fragment stage runs after ALBEDO, ORM, NORMAL, etc, are calculated, letting you modify or completely override them before lighting.
   * Convenient default values are already set:

     ```glsl
     vec3 POSITION   = aPosition;
     vec2 TEXCOORD   = uMaterial.texOffset + aTexCoord * uMaterial.texScale;
     vec4 COLOR      = aColor * iColor;
     vec3 NORMAL     = aNormal;
     vec4 TANGENT    = aTangent;
     ```
   * You also have access to uniforms, matrices, and globals like `TIME`.

2. **Uniform Blocks**

   * **Static Buffer (`StaticBuffer`)**

     * One per shader, optional.
     * Stored exactly as declared in the shader (`std140`).
     * Can be updated fully or partially.
     * Same for all draw calls in a frame. Only the last update before `HP_End3D()` counts.
   * **Dynamic Buffer (`DynamicBuffer`)**

     * Optional, global buffer that can hold multiple per-frame copies for different draw calls.
     * Must be uploaded fully per draw call.
     * Cleared at the end of each frame.
     * Perfect for per-draw tweaks.
   * Both buffers require **std140 layout**, so size modulo 16 and proper padding.

3. **Texture Samplers**

   * Up to 4 samplers per shader: `Texture0` .. `Texture3`.
   * Each is a `sampler2D`.
   * Set them with `HP_SetMaterialShaderTexture(shader, slot, texture)`.
   * If you pass `NULL`, a white texture will be used.
   * Keeps things simple and avoids conflicts with internal samplers.

4. **How Override Works**
    * Hyperion defines dummy macros (`#define vertex()` and `#define fragment()`) that are called by defeault in default material shaders.
    * When the user provides their own code Hyperion replaces the dummy macro definition with the user's code, which contains the `vertex()` and `fragment()` functions.
    * This macro replacement is the only shader source processing Hyperion performs, keeping shader loading simple and efficient as possible.

#### API

```c
HPAPI HP_MaterialShader* HP_CreateMaterialShader(const char* vertCode, const char* fragCode);
HPAPI HP_MaterialShader* HP_LoadMaterialShader(const char* vertFile, const char* fragFile);
void HP_DestroyMaterialShader(HP_MaterialShader* shader);

void HP_UpdateStaticMaterialBuffer(HP_MaterialShader* shader, size_t offset, size_t size, const void* data);
void HP_UpdateDynamicMaterialBuffer(HP_MaterialShader* shader, size_t size, const void* data);

HPAPI void HP_SetMaterialShaderTexture(HP_MaterialShader* shader, int slot, const HP_Texture* texture);
```

* Static buffer updates stick around for the shader.
* Dynamic buffer updates are per draw call and reset each frame.
* Texture slots are mapped automatically based on the shader's predefined names.

#### Usage Example

```glsl
void vertex() {
    // Make vertices bounce a bit
    POSITION.y += sin(TIME + POSITION.x) * 0.1;
}

void fragment() {
    // Add a tiny emission glow
    EMISSION += vec3(0.1, 0.2, 0.3);
}
```

```c
HP_UpdateStaticMaterialShaderBuffer(shader, 0, sizeof(HP_Mat4), &cameraMatrix);
HP_UpdateDynamicMaterialShaderBuffer(shader, sizeof(HP_Vec4), &drawColor);
HP_SetMaterialShaderTexture(shader, 0, textureAlbedo);
HP_DrawMesh3D(mesh, shader);
```

#### TL;DR

This gives you a good control over your material shaders, you can extend the pipeline, tweak per-draw uniforms, and assign textures safely. Everything just works with forward, pre-pass, and shadow rendering.
