### PR TITLE
Add missing `#include <stdbool.h>`

### DIFF
--- a/include/NX/NX_AudioClip.h
+++ b/include/NX/NX_AudioClip.h
@@ -10,6 +10,7 @@
 #define NX_AUDIO_CLIP_H
 
 #include "./NX_API.h"
+#include <stdbool.h>
 
 // ============================================================================
 // TYPES DEFINITIONS

--- a/include/NX/NX_AudioStream.h
+++ b/include/NX/NX_AudioStream.h
@@ -10,6 +10,7 @@
 #define NX_AUDIO_STREAM_H
 
 #include "./NX_API.h"
+#include <stdbool.h>
 
 // ============================================================================
 // TYPES DEFINITIONS


### PR DESCRIPTION
`bool` was used in `NX_AudioClip.h` and `NX_AudioStream.h` without including `stdbool.h`